### PR TITLE
Rename inner value

### DIFF
--- a/specs/InternationalBankAccountNumber.spec.ts
+++ b/specs/InternationalBankAccountNumber.spec.ts
@@ -128,7 +128,7 @@ describe('IBAN', () => {
         "(iban) ",
         "iban:",
         "IBAN: "])('we prefxi %s can be parsed', (s) => {
-            const iban = InternationalBankAccountNumber.parse(s+'NL20INGB0001234567');
+            const iban = InternationalBankAccountNumber.parse(s + 'NL20INGB0001234567');
             expect(iban.toString()).toBe('NL20INGB0001234567');
         });
 

--- a/src/Guid.ts
+++ b/src/Guid.ts
@@ -10,46 +10,46 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      * @remarks It is the default constructor, for creating an actual GUID
      *          you will normally use Guid.newGuid() or Guid.parse(string).
      */
-    private constructor(v: string) {
-        this.v = v;
+    private constructor(value: string) {
+        this.value = value;
     }
 
     /**
      * The underlying value.
      */
-    private readonly v: string; //= ;
+    private readonly value: string;
 
     /** 
      * Returns a string that represents the current GUID.
      */
     public toString(): string {
-        return this.v;
+        return this.value;
     }
     /** 
      * Returns a string that represents the current GUID.
      */
     public format(f?: string): string {
         switch (f) {
-            case 'B': return '{' + this.v + '}';
-            case 'b': return '{' + this.v.toLowerCase() + '}';
-            case 'S': return this.v.replace(/-/g, '');
-            case 's': return this.v.replace(/-/g, '').toLowerCase();
-            case 'l': return this.v.toLowerCase();
-            case 'U': case 'u': default: return this.v;
+            case 'B': return '{' + this.value + '}';
+            case 'b': return '{' + this.value.toLowerCase() + '}';
+            case 'S': return this.value.replace(/-/g, '');
+            case 's': return this.value.replace(/-/g, '').toLowerCase();
+            case 'l': return this.value.toLowerCase();
+            case 'U': case 'u': default: return this.value;
         }
     }
     /** 
      * Returns a JSON representation of the GUID.
      */
     public toJSON(): string {
-        return this.v;
+        return this.value;
     }
 
     /**
      * Returns the version of the GUID.
      */
     public get version(): number {
-        return parseInt(this.v.substring(14, 15));
+        return parseInt(this.value.substring(14, 15));
     }
 
     /**
@@ -57,10 +57,8 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      * representing the same value, otherwise false.
      */
     public equals(other: any): boolean {
-        return other !== null &&
-            other !== undefined &&
-            other instanceof (Guid) &&
-            other.v === this.v;
+        return other instanceof (Guid) 
+            && other.value === this.value;
     }
 
     /**
@@ -132,7 +130,7 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
         if (seed !== null && seed instanceof (Guid)) {
             let merged = '';
             for (let i = 0; i < 36; i++) {
-                const l = '0123456789ABCDEF'.indexOf(seed.v.charAt(i));
+                const l = '0123456789ABCDEF'.indexOf(seed.value.charAt(i));
                 const r = '0123456789ABCDEF'.indexOf(v.charAt(i));
                 merged += l === -1 || r === -1 ? v.charAt(i) : '0123456789ABCDEF'.charAt(l ^ r);
             }

--- a/src/InternationalBankAccountNumber.ts
+++ b/src/InternationalBankAccountNumber.ts
@@ -6,24 +6,24 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
      * @remarks It is the default constructor, for creating an actual IBAN
      *          you will normally use InternationalBankAccountNumber.parse(string).
      */
-    private constructor(v: string) {
-        this.v = v;
+    private constructor(value: string) {
+        this.value = value;
     }
 
     /**
      * The underlying value.
      */
-    private readonly v;
+    private readonly value;
 
     public get country() {
-        return this.v.substring(0, 2);
+        return this.value.substring(0, 2);
     }
 
     /** 
     * Returns a string that represents the current IBAN.
     */
     public toString(): string {
-        return this.v;
+        return this.value;
     }
 
     /** 
@@ -41,8 +41,8 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
     */
     public format(f?: string): string {
         switch (f) {
-            case 'u': case 'm': return this.v.toLowerCase();
-            case 'U': case 'M': return this.v;
+            case 'u': case 'm': return this.value.toLowerCase();
+            case 'U': case 'M': return this.value;
             case 'f': return this.humanReadable(' ').toLowerCase();
             case 'F': return this.humanReadable(' ');
             case 'h': return this.humanReadable(' ').toLowerCase();
@@ -51,7 +51,7 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
     }
 
     private humanReadable(ch: string): string {
-        return this.v.replace(/.{4}(?!$)/g, '$&' + ch);
+        return this.value.replace(/.{4}(?!$)/g, '$&' + ch);
     }
 
     /**
@@ -60,14 +60,14 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
      */
     public equals(other: any): boolean {
         return other instanceof (InternationalBankAccountNumber)
-            && other.v === this.v;
+            && other.value === this.value;
     }
 
     /** 
      * Returns a JSON representation of the IBAN.
      */
     public toJSON(): string {
-        return this.v;
+        return this.value;
     }
 
     /**

--- a/src/PostalCode.ts
+++ b/src/PostalCode.ts
@@ -1,4 +1,4 @@
-import { Unparsable } from '../src';
+import { Svo, Unparsable } from '../src';
 
 class PostalCodeInfo {
     public constructor(pattern: RegExp, search?: RegExp | undefined, replace?: string | undefined) {
@@ -32,20 +32,20 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     * @remarks It is the default constructor, for creating an actual
     *          PostalCode use PostalCode.parse(string).
     */
-    private constructor(v: string) {
-        this.v = v;
+    private constructor(value: string) {
+        this.value = value;
      }
 
     /**
      * The underlying value.
      */
-    private readonly v: string;
+    private readonly value: string;
 
     /** 
     * Returns a string that represents the current postal code.
     */
     toString(): string {
-        return this.v;
+        return this.value;
     }
 
     /** 
@@ -54,16 +54,16 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     format(f: string): string {
         const info = PostalCode.Infos.get(f);
 
-        return info && info.isValid(this.v)
-            ? info.format(this.v)
-            : this.v;
+        return info && info.isValid(this.value)
+            ? info.format(this.value)
+            : this.value;
     }
 
     /** 
      * Returns a JSON representation of the postal code.
      */
     public toJSON(): string {
-        return this.v;
+        return this.value;
     }
 
     /**
@@ -72,7 +72,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      */
     public equals(other: any): boolean {
         return other instanceof (PostalCode) 
-            && other.v === this.v;
+            && other.value === this.value;
     }
 
     /**
@@ -83,8 +83,8 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     public isValid(country: string): boolean {
         const info = PostalCode.Infos.get(country);
         return info === undefined
-            ? this.v === ''
-            : info.isValid(this.v);
+            ? this.value === ''
+            : info.isValid(this.value);
     }
 
     /**
@@ -126,15 +126,11 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
 		// an empty string should equal PostalCode.Empty.
 		if (s === '' || s === null) { return PostalCode.empty(); }
 
-		s = PostalCode.strip(s).toUpperCase();
+		s = Svo.unify(s);
 		return s.length >= 2 && s.length <= 10
             ? new PostalCode(s)
             : undefined;
 	}
-
-    private static strip(s: string): string {
-        return s.replace(/[_\- \.]/g, '');
-    }
 
     private static Infos = new Map<string, PostalCodeInfo>([
         ['AD', new PostalCodeInfo(/^(AD)?[1-7][0-9]{2}$/, /^(AD)?(...)$/, 'AD-$2')],


### PR DESCRIPTION
As pointed out by @pmdevers in #17, the name of the inner value of an SVO should be `value`, not `v`.