### PR TITLE
Represent empty with null

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,21 @@ As developement tool, we addopted [TypeScript](http://typescriptlang.org/).
 # Single Value Object
 A Value Object that can be represented by a single scalar.
 
+## Empty state
+In Qowaiv.NET - for non continuous - SVO's there is a not-null state: The
+default state of the `struct`. Such concept does not exist in JavaScript. As a
+result, for empty states, `null` is used. So for example:
+
+``` TypeScript
+const svo = PostalCode.parse(''); // null.
+```
+
 ## Qowaiv types
 
 ### Guid
 Represents a Globally Unique Identifier (GUID). 
 
 ``` TypeScript
-const empty = Guid.Empty();  // 00000000-0000-0000-0000-000000000000
 const next = Guid.newGuid(); // 123E4567-E89B-12D3-A456-426655440000
 const str = next.format("B"); // {123E4567-E89B-12D3-A456-426655440000}
 ```
@@ -42,13 +50,11 @@ const lower = iban.format('h');  // 'nl20 ingb 0001 2345 67' with nbsp.
 Represents a postal code. It supports validation for all countries.
 
 ``` TypeScript
-let empty = PostalCode.empty();  // ''
-
-let dutch = PostalCode.parse('2624DP');
+const dutch = PostalCode.parse('2624DP');
 dutch.isValid('NL'); // true
 dutch.isValid('BE'); // false
 
-let argentina = PostalCode.Parse('Z1230ABC');
+const argentina = PostalCode.Parse('Z1230ABC');
 argentina.format('AR'); // Z 1230 ABC
 argentina.format('NL'); // Z1230ABC
 ```

--- a/specs/Guid.spec.ts
+++ b/specs/Guid.spec.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { Guid } from '../src';
 
 describe("GUID: ", () => {
+
+    test.each([
+        '',
+        null,
+        undefined,
+    ])('parses %s as null', (s) => {
+        const svo = Guid.parse(s!);
+        expect(svo).toBeNull();
+    });
 
     it("The version of newGuid() should be valid", () => {
 
@@ -12,7 +21,7 @@ describe("GUID: ", () => {
     it("The version of newGuid(seed) should be valid", () => {
 
         var seed = Guid.parse("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
-        var guid = Guid.newGuid(seed);
+        var guid = Guid.newGuid(seed!);
         expect(Guid.parse(guid.toString())).toBeDefined();
     });
 
@@ -25,44 +34,37 @@ describe("GUID: ", () => {
     it("The version of some random guid should be 4", () => {
 
         var guid = Guid.parse("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
-        expect(guid.version).toBe(4);
+        expect(guid!.version).toBe(4);
     });
-
-    it("The version of empty() should be 0", () => {
-
-        var guid = Guid.empty();
-        expect(guid.version).toBe(0);
-    });
-
 
     it("format('B') should have brackets.", () => {
 
         var guid = Guid.parse("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
-        expect(guid.format("B")).toBe("{DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189}");
+        expect(guid!.format("B")).toBe("{DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189}");
     });
 
     it("format('b') should have brackets and be lowercase.", () => {
 
         var guid = Guid.parse("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
-        expect(guid.format("b")).toBe("{dc7fba65-df6f-4cb9-8faa-6c7b5654f189}");
+        expect(guid!.format("b")).toBe("{dc7fba65-df6f-4cb9-8faa-6c7b5654f189}");
     });
 
     it("format('S') should have no dashes.", () => {
 
         var guid = Guid.parse("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
-        expect(guid.format("S")).toBe("DC7FBA65DF6F4CB98FAA6C7B5654F189");
+        expect(guid!.format("S")).toBe("DC7FBA65DF6F4CB98FAA6C7B5654F189");
     });
 
     it("format('s') should have no dashed and be lowercase.", () => {
 
         var guid = Guid.parse("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
-        expect(guid.format("s")).toBe("dc7fba65df6f4cb98faa6c7b5654f189");
+        expect(guid!.format("s")).toBe("dc7fba65df6f4cb98faa6c7b5654f189");
     });
 
     it("parse('{DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189}') should be parseable.", () => {
 
         var guid = Guid.parse("{DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189}");
-        expect(guid.format("U")).toBe("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
+        expect(guid!.format("U")).toBe("DC7FBA65-DF6F-4CB9-8FAA-6C7B5654F189");
     });
 
     it("Parse('Nonsense') should not be parseable.", () => {

--- a/specs/InternationalBankAccountNumber.spec.ts
+++ b/specs/InternationalBankAccountNumber.spec.ts
@@ -1,7 +1,16 @@
-import { describe, expect, beforeEach, it, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { InternationalBankAccountNumber } from '../src';
 
 describe('IBAN', () => {
+     test.each([
+            '',
+            null,
+            undefined,
+        ])('parses %s as null', (s) => {
+            const svo = InternationalBankAccountNumber.parse(s!);
+            expect(svo).toBeNull();
+        });
+
     test.each([
         'AD1200012030200359100100',
         'AE950210000000693123456',
@@ -110,7 +119,7 @@ describe('IBAN', () => {
         'TD8960002000010271091600153',
         'TG53TG0090604310346500400070'])('parses %s', (s) => {
             const iban = InternationalBankAccountNumber.parse(s);
-            expect(iban.toString()).toBe(s);
+            expect(iban!.toString()).toBe(s);
         });
 
 
@@ -119,7 +128,7 @@ describe('IBAN', () => {
         "US41 1234 5678 90AB CDEF GHIJ KLMN OPQR",
         "US19 T3NB 32YP 2588 8395 8870 7523 1343 8517"])('%s for countries without IBAN', (s) => {
             const iban = InternationalBankAccountNumber.parse(s);
-            expect(iban.format('F')).toBe(s);
+            expect(iban!.format('F')).toBe(s);
         });
 
     test.each([
@@ -129,7 +138,7 @@ describe('IBAN', () => {
         "iban:",
         "IBAN: "])('we prefxi %s can be parsed', (s) => {
             const iban = InternationalBankAccountNumber.parse(s + 'NL20INGB0001234567');
-            expect(iban.toString()).toBe('NL20INGB0001234567');
+            expect(iban!.toString()).toBe('NL20INGB0001234567');
         });
 
 
@@ -149,40 +158,40 @@ describe('IBAN', () => {
         const iban3 = InternationalBankAccountNumber.parse('CG3930011000101013451300019');
         const iban4 = InternationalBankAccountNumber.parse('CI15QO4875019424693110901733');
 
-        expect(iban1.format('F')).toBe('CH36 0838 7000 0010 8017 3');
-        expect(iban2.format('F')).toBe('NL20 INGB 0001 2345 67');
-        expect(iban3.format('F')).toBe('CG39 3001 1000 1010 1345 1300 019');
-        expect(iban4.format('F')).toBe('CI15 QO48 7501 9424 6931 1090 1733');
+        expect(iban1!.format('F')).toBe('CH36 0838 7000 0010 8017 3');
+        expect(iban2!.format('F')).toBe('NL20 INGB 0001 2345 67');
+        expect(iban3!.format('F')).toBe('CG39 3001 1000 1010 1345 1300 019');
+        expect(iban4!.format('F')).toBe('CI15 QO48 7501 9424 6931 1090 1733');
     });
 
     it('formats to human readable with f', () => {
         const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
-        expect(iban.format('f')).toBe('nl20 ingb 0001 2345 67');
+        expect(iban!.format('f')).toBe('nl20 ingb 0001 2345 67');
     });
 
     it('formats to human readable with H using nbsp', () => {
         const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
-        expect(iban.format('H')).toBe('NL20 INGB 0001 2345 67');
+        expect(iban!.format('H')).toBe('NL20 INGB 0001 2345 67');
     });
 
     it('formats to human readable with h using nbsp', () => {
         const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
-        expect(iban.format('h')).toBe('nl20 ingb 0001 2345 67');
+        expect(iban!.format('h')).toBe('nl20 ingb 0001 2345 67');
     });
 
     it('formats to human readable with using nbsp, by default', () => {
         const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
-        expect(iban.format()).toBe('NL20 INGB 0001 2345 67');
+        expect(iban!.format()).toBe('NL20 INGB 0001 2345 67');
     });
 
     test.each(['M', 'U'])('format(%s) returns machine-readable/unformatted', (f) => {
         const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
-        expect(iban.format(f)).toBe('NL20INGB0001234567');
+        expect(iban!.format(f)).toBe('NL20INGB0001234567');
     });
 
     test.each(['m', 'u'])('format(%s) returns machine-readable/unformatted lowercased', (f) => {
         const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
-        expect(iban.format(f)).toBe('nl20ingb0001234567');
+        expect(iban!.format(f)).toBe('nl20ingb0001234567');
     });
 
     it('should return undefined when input is more than 10 characters', () => {
@@ -202,7 +211,7 @@ describe('IBAN', () => {
         const iban1 = InternationalBankAccountNumber.parse('NL20INGB0001234567');
         const iban2 = InternationalBankAccountNumber.parse('NL20INGB0001234567');
         const iban3 = InternationalBankAccountNumber.parse('CH3608387000001080173');
-        expect(iban1.equals(iban2)).toBe(true);
-        expect(iban1.equals(iban3)).toBe(false);
+        expect(iban1!.equals(iban2)).toBe(true);
+        expect(iban1!.equals(iban3)).toBe(false);
     });
 });

--- a/specs/PostalCode.spec.ts
+++ b/specs/PostalCode.spec.ts
@@ -1,36 +1,41 @@
-import { describe, expect, beforeEach, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { PostalCode } from '../src';
 
 describe('PostalCode', () => {
-    it('should create an empty postal code', () => {
-        const postalCode = PostalCode.empty();
-        expect(postalCode.toString()).toBe('');
+
+    test.each([
+        '',
+        null,
+        undefined,
+    ])('parses %s as null', (s) => {
+        const svo = PostalCode.parse(s!);
+        expect(svo).toBeNull();
     });
 
-    it('should parse and format a postal code', () => {
+    it('parses and format a postal code', () => {
         const postalCode = PostalCode.parse(' AD700 ');
-        expect(postalCode.toString()).toBe('AD700');
-        expect(postalCode.format('AD')).toBe('AD-700');
+        expect(postalCode!.toString()).toBe('AD700');
+        expect(postalCode!.format('AD')).toBe('AD-700');
     });
 
     it('does not format a postal code that is not valid for a country', () => {
         const postalCode = PostalCode.parse('123456');
-        expect(postalCode.toString()).toBe('123456');
-        expect(postalCode.format('NL')).toBe('123456');
+        expect(postalCode!.toString()).toBe('123456');
+        expect(postalCode!.format('NL')).toBe('123456');
     });
 
-    it('should validate a postal code for a specific country', () => {
+    it('validates a postal code for a specific country', () => {
         const postalCode = PostalCode.parse('AD700');
-        expect(postalCode.isValid('AD')).toBe(true);
-        expect(postalCode.isValid('US')).toBe(false);
+        expect(postalCode!.isValid('AD')).toBe(true);
+        expect(postalCode!.isValid('US')).toBe(false);
     });
 
-    it('should return undefined when input is more than 10 characters', () => {
+    it('returns undefined when input is more than 10 characters', () => {
         const postalCode = PostalCode.tryParse('INVALIDINVALID');
         expect(postalCode).toBeUndefined();
     });
 
-    it('should return null when input is less than 2 characters', () => {
+    it('returns undefined when input is less than 2 characters', () => {
         const postalCode = PostalCode.tryParse('I');
         expect(postalCode).toBeUndefined();
     });
@@ -47,7 +52,7 @@ describe('PostalCode', () => {
         const code1 = PostalCode.parse('AD700');
         const code2 = PostalCode.parse('AD700');
         const code3 = PostalCode.parse('US90210');
-        expect(code1.equals(code2)).toBe(true);
-        expect(code1.equals(code3)).toBe(false);
+        expect(code1!.equals(code2)).toBe(true);
+        expect(code1!.equals(code3)).toBe(false);
     });
 });

--- a/src/Guid.ts
+++ b/src/Guid.ts
@@ -1,4 +1,4 @@
-import { Unparsable } from '../src';
+import { Svo, Unparsable } from '../src';
 
 /**
  * Represents a Globally unique identifier (GUID).
@@ -75,7 +75,7 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      * @param {string} s A string containing GUID to convert.
      * @returns {Guid} A GUID if valid, otherwise trhows.
      */
-    public static parse(s: string): Guid {
+    public static parse(s: string): Guid | null {
         const svo = Guid.tryParse(s);
 
         if (svo === undefined) {
@@ -89,12 +89,13 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      * @param {string} s A string containing GUID to convert.
      * @returns {Guid} A GUID if valid, otherwise undefined.
      */
-    public static tryParse(s: string): Guid | undefined {
+    public static tryParse(s: string): Guid | null | undefined {
 
-        // an empty string should equal Guid.Empty.
-        if (s === '' || s === null) { return Guid.empty(); }
-
+        if(Svo.isEmpty(s)) {return null;}
+        
         s = Guid.unify(s);
+
+        if( s=== '00000000-0000-0000-0000-000000000000') {return null;}
 
         // if the value parameter is valid
         return /^[0-9ABCDEF]{32}$/.test(s)
@@ -103,20 +104,14 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
     }
 
     private static unify(s: string): string {
-        s = s.replace(/-/g, '').trim().toUpperCase();
+        s = Svo.unify(s);
         return s.length > 2 && s[0] == '{' && s[s.length - 1] == '}'
             ? s.substring(1, s.length - 1)
             : s;
     }
+    
     private static unstrip(s: string): string {
         return s.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5').toUpperCase();
-    }
-
-    /**
-     * Returns a new empty GUID.
-     */
-    public static empty(): Guid {
-        return new Guid('00000000-0000-0000-0000-000000000000');
     }
 
     /**

--- a/src/InternationalBankAccountNumber.ts
+++ b/src/InternationalBankAccountNumber.ts
@@ -91,7 +91,7 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
      * @param {string} s A string containing IBAN to convert.
      * @returns {InternationalBankAccountNumber} IBAN if valid, otherwise throws.
      */
-    public static parse(s: string): InternationalBankAccountNumber {
+    public static parse(s: string): InternationalBankAccountNumber | null {
         const svo = InternationalBankAccountNumber.tryParse(s);
 
         if (svo === undefined) {
@@ -105,10 +105,9 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
      * @param {string} s A string containing IBAN to convert.
      * @returns {InternationalBankAccountNumber} A IBAN if valid, otherwise undefined.
      */
-    public static tryParse(s: string): InternationalBankAccountNumber | undefined {
+    public static tryParse(s: string): InternationalBankAccountNumber | null | undefined {
 
-        // an empty string should equal IBAN.Empty.
-        if (s === '' || s === null) { return InternationalBankAccountNumber.empty(); }
+        if (Svo.isEmpty(s)) { return null; }
 
         // trim '(IBAN)', 'IBAN ', and 'IBAN:'.
         s = s.replace(/\s*(IBAN\s+|IBAN\:|\(IBAN\))\s*/i, '');

--- a/src/PostalCode.ts
+++ b/src/PostalCode.ts
@@ -82,16 +82,8 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      */
     public isValid(country: string): boolean {
         const info = PostalCode.Infos.get(country);
-        return info === undefined
-            ? this.value === ''
-            : info.isValid(this.value);
-    }
-
-    /**
-    * Returns a new empty postal code.
-    */
-    public static empty(): PostalCode {
-        return new PostalCode('');
+        return info !== undefined
+            && info.isValid(this.value);
     }
 
     /**
@@ -99,7 +91,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      * @param {string} s A JSON string representing the postal code.
      * @returns {PostalCode} A postal code if valid, otherwise undefined.
      */
-    public static fromJSON(s: string): PostalCode | undefined {
+    public static fromJSON(s: string): PostalCode | null {
         return PostalCode.parse(s);
     }
 
@@ -108,7 +100,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
 	 * @param {string} s A string containing postal code to convert.
 	 * @returns {PostalCode} A postal code if valid, otherwise trhows.
 	 */
-	public static parse(s: string): PostalCode {
+	public static parse(s: string): PostalCode | null {
 		const svo = PostalCode.tryParse(s);
 
         if (svo === undefined) {
@@ -122,9 +114,9 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
 	 * @param {string} s A string containing postal code to convert.
 	 * @returns {PostalCode} A postal code if valid, otherwise undefined.
 	 */
-	public static tryParse(s: string): PostalCode | undefined {
-		// an empty string should equal PostalCode.Empty.
-		if (s === '' || s === null) { return PostalCode.empty(); }
+	public static tryParse(s: string): PostalCode | null | undefined {
+
+        if (Svo.isEmpty(s)) { return null; }
 
 		s = Svo.unify(s);
 		return s.length >= 2 && s.length <= 10

--- a/src/Svo.ts
+++ b/src/Svo.ts
@@ -4,6 +4,16 @@
 export class Svo {
 
     /**
+     * Returns true if the string is empty, null, or undefined.
+     * @param {string} s the input to verify.
+     */
+    public static isEmpty(s: string) : boolean {
+        return s === ''
+            || s === null
+            || s === undefined;
+    }
+
+    /**
      * Unifies an input string.
      * @param {string} s the
      * @param {boolean} lowercase indicates if the string should be lower- or uppercase.


### PR DESCRIPTION
## Empty state
In Qowaiv.NET - for non continuous - SVO's there is a not-null state: The default state of the `struct`. Such concept does not exist in JavaScript. As a result, for empty states, `null` is used. So for example:

``` TypeScript
const svo = PostalCode.parse(''); // null.
```

Closes #9