### PR TITLE
Handling unparsable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,23 @@ A Value Object that can be represented by a single scalar.
 ## Empty state
 In Qowaiv.NET - for non continuous - SVO's there is a not-null state: The
 default state of the `struct`. Such concept does not exist in JavaScript. As a
-result, for empty states, `null` is used. So for example:
+result, for empty states, `undefined` is used. So for example:
 
 ``` TypeScript
-const svo = PostalCode.parse(''); // null.
+const svo = PostalCode.parse(''); // undefined.
+```
+
+To not to have to rely on try-catch every SVO has an `tryParse` alternative.
+This resturns an `Unparsable` object, containing an error message and the
+attempted value once a value can not be parsed, this allows clean code to
+handle the unparsable state:
+
+``` TypeScript
+const svo = Guid.pars('not-a-guid'); // Unparsable object.
+
+if (svo instanceof (Unparsable)) {
+    // handle the unparsable state
+}
 ```
 
 ## Qowaiv types

--- a/specs/EmailAddress.spec.ts
+++ b/specs/EmailAddress.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest';
-import { EmailAddress } from '../src';
+import { EmailAddress, Unparsable } from '../src';
 
 describe('Email address', () => {
 
@@ -9,9 +9,9 @@ describe('Email address', () => {
         '',
         null,
         undefined,
-    ])('parses %s as null', (s) => {
+    ])('parses %s as undefined', (s) => {
         const svo = EmailAddress.parse(s!);
-        expect(svo).toBeNull();
+        expect(svo).toBeUndefined();
     });
 
     describe('length', () => {
@@ -23,13 +23,13 @@ describe('Email address', () => {
             ])
             ('not more than 254 (%s)', (s) => {
 
-                const svo = EmailAddress.tryParse(s);
+                const svo = EmailAddress.parse(s);
                 expect(svo?.length).toBe(254);
             });
 
         it('not 255 or longer', () => {
             const svo = EmailAddress.tryParse('i234567890_234567890_234567890_234567890_234567890_234567890_234@long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long.long1');
-            expect(svo).toBeUndefined();
+            expect(svo).toBeInstanceOf(Unparsable);
         })
     });
 
@@ -110,7 +110,7 @@ describe('Email address', () => {
             ('%s is not allowed', (ch) => {
 
                 const svo = EmailAddress.tryParse(`info@${ch}.org`);
-                expect(svo).toBeUndefined();
+                expect(svo).toBeInstanceOf(Unparsable);
             });
 
         test.each([
@@ -118,7 +118,8 @@ describe('Email address', () => {
             'com',
             'museum',
             'topleveldomain',
-            'co.jp'])
+            'co.jp'
+        ])
             ('topdomain %s can contain any letter', (top) => {
                 const s = `info@qowaiv.${top}`;
                 const svo = EmailAddress.tryParse(s);
@@ -416,7 +417,7 @@ describe('Email address', () => {
     ])
         ('can not parse %s', (s) => {
             const svo = EmailAddress.tryParse(s);
-            expect(svo).toBeUndefined();
+            expect(svo).toBeInstanceOf(Unparsable);
         });
 });
 

--- a/specs/Guid.spec.ts
+++ b/specs/Guid.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest';
-import { Guid } from '../src';
+import { Guid, Unparsable } from '../src';
 
 describe("GUID: ", () => {
 
@@ -9,9 +9,9 @@ describe("GUID: ", () => {
         '',
         null,
         undefined,
-    ])('parses %s as null', (s) => {
+    ])('parses %s as undefined', (s) => {
         const svo = Guid.parse(s!);
-        expect(svo).toBeNull();
+        expect(svo).toBeUndefined();
     });
 
     it("The version of newGuid() should be valid", () => {
@@ -72,7 +72,7 @@ describe("GUID: ", () => {
     it("Parse('Nonsense') should not be parseable.", () => {
 
         const svo = Guid.tryParse("Nonsense");
-        expect(svo).toBeUndefined();
+        expect(svo).toBeInstanceOf(Unparsable);
     });
 
     it('throws for invalid input on parse', () => {

--- a/specs/InternationalBankAccountNumber.spec.ts
+++ b/specs/InternationalBankAccountNumber.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest';
-import { InternationalBankAccountNumber } from '../src';
+import { InternationalBankAccountNumber, Unparsable } from '../src';
 
 describe('IBAN', () => {
 
@@ -14,9 +14,9 @@ describe('IBAN', () => {
         '',
         null,
         undefined,
-    ])('parses %s as null', (s) => {
+    ])('parses %s as undefined', (s) => {
         const svo = InternationalBankAccountNumber.parse(s!);
-        expect(svo).toBeNull();
+        expect(svo).toBeUndefined();
     });
 
     test.each([
@@ -152,12 +152,12 @@ describe('IBAN', () => {
 
     it('Does not parse IBAN with invalid checksum', () => {
         const iban = InternationalBankAccountNumber.tryParse('NL21INGB0001234567');
-        expect(iban).toBeUndefined();
+        expect(iban).toBeInstanceOf(Unparsable);
     });
 
     it('contains the country linked', () => {
-        const iban = InternationalBankAccountNumber.tryParse('NL20INGB0001234567');
-        expect(iban?.country).toBe('NL');
+        const iban = InternationalBankAccountNumber.parse('NL20INGB0001234567');
+        expect(iban!.country).toBe('NL');
     })
 
     it('formats to human readable with F', () => {
@@ -204,7 +204,7 @@ describe('IBAN', () => {
 
     it('should return undefined when input is more than 10 characters', () => {
         const postalCode = InternationalBankAccountNumber.tryParse('INVALID');
-        expect(postalCode).toBeUndefined();
+        expect(postalCode).toBeInstanceOf(Unparsable);
     });
 
     it('throws for invalid input on parse', () => {

--- a/specs/PostalCode.spec.ts
+++ b/specs/PostalCode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from 'vitest';
-import { PostalCode } from '../src';
+import { PostalCode, Unparsable } from '../src';
 
 describe('PostalCode', () => {
 
@@ -9,9 +9,9 @@ describe('PostalCode', () => {
         '',
         null,
         undefined,
-    ])('parses %s as null', (s) => {
+    ])('parses %s as undefined', (s) => {
         const svo = PostalCode.parse(s!);
-        expect(svo).toBeNull();
+        expect(svo).toBeUndefined();
     });
 
     it('has an accessble length', () => {
@@ -39,12 +39,12 @@ describe('PostalCode', () => {
 
     it('returns undefined when input is more than 10 characters', () => {
         const postalCode = PostalCode.tryParse('INVALIDINVALID');
-        expect(postalCode).toBeUndefined();
+        expect(postalCode).toBeInstanceOf(Unparsable);
     });
 
-    it('returns undefined when input is less than 2 characters', () => {
+    it('returns Unparsable when input is less than 2 characters', () => {
         const postalCode = PostalCode.tryParse('I');
-        expect(postalCode).toBeUndefined();
+        expect(postalCode).toBeInstanceOf(Unparsable);
     });
 
     it('throws for invalid input on parse', () => {

--- a/src/EmailAddress.ts
+++ b/src/EmailAddress.ts
@@ -311,7 +311,7 @@ export class EmailAddress implements IEquatable, IJsonStringifyable {
      * @param {string} s A JSON string representing the email address.
      * @returns {EmailAddress} A email address if valid, otherwise undefined.
      */
-    public static fromJSON(s: string): EmailAddress | null {
+    public static fromJSON(s: string): EmailAddress | undefined {
         return EmailAddress.parse(s);
     }
 
@@ -320,11 +320,11 @@ export class EmailAddress implements IEquatable, IJsonStringifyable {
      * @param {string} s A string containing email address to convert.
      * @returns {EmailAddress} email address if valid, otherwise throws.
      */
-    public static parse(s: string | null | undefined): EmailAddress | null {
+    public static parse(s: string | null | undefined): EmailAddress | undefined {
         const svo = EmailAddress.tryParse(s);
 
-        if (svo === undefined) {
-            throw new Unparsable('Not a valid email address', s);
+        if (svo instanceof (Unparsable)) {
+            throw svo;
         }
         return svo;
     }
@@ -334,12 +334,12 @@ export class EmailAddress implements IEquatable, IJsonStringifyable {
      * @param {string} s A string containing email address to convert.
      * @returns {EmailAddress} A email address if valid, otherwise undefined.
      */
-    public static tryParse(s: string | null | undefined): EmailAddress | null | undefined {
-        if (Svo.isEmpty(s)) return null;
+    public static tryParse(s: string | null | undefined): EmailAddress | Unparsable | undefined {
+        if (Svo.isEmpty(s)) return undefined;
 
         const svo = new Parser(s!.trim()).parse();
         return svo
             ? new EmailAddress(svo)
-            : undefined;
+            : new Unparsable('Not a valid email address', s);
     }
 }

--- a/src/Guid.ts
+++ b/src/Guid.ts
@@ -66,7 +66,7 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
       * @param {string} s A JSON string representing the GUID.
       * @returns {Guid} A GUID if valid, otherwise undefined.
       */
-    public static fromJSON(s: string): Guid | null {
+    public static fromJSON(s: string): Guid | undefined {
         return Guid.parse(s);
     }
 
@@ -75,11 +75,11 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      * @param {string} s A string containing GUID to convert.
      * @returns {Guid} A GUID if valid, otherwise trhows.
      */
-    public static parse(s: string | null | undefined): Guid | null {
+    public static parse(s: string | null | undefined): Guid | undefined {
         const svo = Guid.tryParse(s);
 
-        if (svo === undefined) {
-            throw new Unparsable('Not a valid GUID', s);
+        if (svo instanceof (Unparsable)) {
+            throw svo;
         }
         return svo;
     }
@@ -89,18 +89,18 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      * @param {string} s A string containing GUID to convert.
      * @returns {Guid} A GUID if valid, otherwise undefined.
      */
-    public static tryParse(s: string | null | undefined): Guid | null | undefined {
+    public static tryParse(s: string | null | undefined): Guid | Unparsable | undefined {
 
-        if (Svo.isEmpty(s)) { return null; }
+        if (Svo.isEmpty(s)) return undefined;
 
-        s = Guid.unify(s!);
+        const u = Guid.unify(s!);
 
-        if (s === '00000000-0000-0000-0000-000000000000') { return null; }
+        if (u === '00000000-0000-0000-0000-000000000000') { return undefined; }
 
         // if the value parameter is valid
-        return /^[0-9ABCDEF]{32}$/.test(s)
-            ? new Guid(Guid.unstrip(s))
-            : undefined;
+        return /^[0-9ABCDEF]{32}$/.test(u)
+            ? new Guid(Guid.unstrip(u))
+            : new Unparsable('Not a valid GUID', s);
     }
 
     private static unify(s: string): string {

--- a/src/PostalCode.ts
+++ b/src/PostalCode.ts
@@ -106,11 +106,11 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      * @param {string} s A string containing postal code to convert.
      * @returns {PostalCode} A postal code if valid, otherwise trhows.
      */
-    public static parse(s: string | null | undefined): PostalCode | null {
+    public static parse(s: string | null | undefined): PostalCode | undefined {
         const svo = PostalCode.tryParse(s);
 
-        if (svo === undefined) {
-            throw new Unparsable('Not a valid postal code', s);
+        if (svo instanceof(Unparsable)) {
+            throw svo;
         }
         return svo;
     }
@@ -120,14 +120,14 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      * @param {string} s A string containing postal code to convert.
      * @returns {PostalCode} A postal code if valid, otherwise undefined.
      */
-    public static tryParse(s: string | null | undefined): PostalCode | null | undefined {
+    public static tryParse(s: string | null | undefined): PostalCode | Unparsable | undefined  {
 
-        if (Svo.isEmpty(s)) { return null; }
+        if (Svo.isEmpty(s)) return undefined;
 
         s = Svo.unify(s!);
         return s.length >= 2 && s.length <= 10
             ? new PostalCode(s)
-            : undefined;
+            : new Unparsable('Not a valid postal code', s);
     }
 
     private static readonly Infos = new Map<string, PostalCodeInfo>([

--- a/src/PostalCode.ts
+++ b/src/PostalCode.ts
@@ -51,14 +51,14 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     /** 
      * Returns a string that represents the current postal code.
      */
-    toString(): string {
+    public toString(): string {
         return this.value;
     }
 
     /** 
      * Returns a string that represents the current postal code.
      */
-    format(f: string): string {
+    public format(f: string): string {
         const info = PostalCode.Infos.get(f);
 
         return info?.isValid(this.value)
@@ -97,7 +97,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      * @param {string} s A JSON string representing the postal code.
      * @returns {PostalCode} A postal code if valid, otherwise undefined.
      */
-    public static fromJSON(s: string): PostalCode | null {
+    public static fromJSON(s: string | null | undefined): PostalCode | undefined {
         return PostalCode.parse(s);
     }
 
@@ -109,7 +109,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     public static parse(s: string | null | undefined): PostalCode | undefined {
         const svo = PostalCode.tryParse(s);
 
-        if (svo instanceof(Unparsable)) {
+        if (svo instanceof (Unparsable)) {
             throw svo;
         }
         return svo;
@@ -120,7 +120,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      * @param {string} s A string containing postal code to convert.
      * @returns {PostalCode} A postal code if valid, otherwise undefined.
      */
-    public static tryParse(s: string | null | undefined): PostalCode | Unparsable | undefined  {
+    public static tryParse(s: string | null | undefined): PostalCode | Unparsable | undefined {
 
         if (Svo.isEmpty(s)) return undefined;
 

--- a/src/PostalCode.ts
+++ b/src/PostalCode.ts
@@ -124,9 +124,9 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
 
         if (Svo.isEmpty(s)) return undefined;
 
-        s = Svo.unify(s!);
-        return s.length >= 2 && s.length <= 10
-            ? new PostalCode(s)
+        const u = Svo.unify(s!);
+        return u.length >= 2 && u.length <= 10
+            ? new PostalCode(u)
             : new Unparsable('Not a valid postal code', s);
     }
 


### PR DESCRIPTION
As we are still in the not yet published state, we still can easily reconsider how to deal with the unparsable state (see #7 ). After a discussion with a colleague (who I consider a front end expert) I reconsidered the first choice. He was not satisfied with the (slightly) different meaning of `null` and `undefined`, and preferred to only have to deal with `undefined`.

So what about this?

``` TypeScript
export class MySvo
{
    public static parse(s: string | null | undefined): MySvo | undefined {
        const svo = MySvo.tryParse(s);

        if (svo instanceof(Unparsable)) {
            throw svo;
        }
        return svo;
    }

    public static tryParse(s: string | null | undefined): MySvo | Unparsable | undefined  {

        if (Svo.isEmpty(s)) return undefined;

        return isValid(s)
            ? new MySvo(s)
            : new Unparsable('Not a valid svo', s);
    }
}
```

The statement ` if (svo instanceof(Unparsable))` is arguably easy to understand, and half as verbose I thought it would be.
