### PR TITLE
Use # field operator for private fields

### DIFF
--- a/src/EmailAddress.ts
+++ b/src/EmailAddress.ts
@@ -223,33 +223,33 @@ export class EmailAddress implements IEquatable, IJsonStringifyable {
      *          you will normally use EmailAddress.parse(string) or EmailAddress.tryParse(string).
      */
     private constructor(value: string) {
-        this.value = value;
+        this.#value = value;
     }
 
     /**
      * The underlying value.
      */
-    private readonly value: string;
+    readonly #value: string;
 
     /**
      * The length of the email address.
      */
     public get length(): number {
-        return this.value.length;
+        return this.#value.length;
     }
 
     /**
      * Indicates if the email address is IP-based.
      */
     public get isIPBased(): boolean {
-        return this.value.endsWith(']');
+        return this.#value.endsWith(']');
     }
 
     /** 
     * Returns a string that represents the current email address.
     */
     public toString(): string {
-        return this.value;
+        return this.#value;
     }
 
     /**
@@ -258,14 +258,14 @@ export class EmailAddress implements IEquatable, IJsonStringifyable {
      */
     public equals(other: unknown): boolean {
         return other instanceof (EmailAddress)
-            && other.value === this.value;
+            && other.#value === this.#value;
     }
 
     /** 
      * Returns a JSON representation of the email address.
      */
     public toJSON(): string {
-        return this.value;
+        return this.#value;
     }
 
     /**

--- a/src/Guid.ts
+++ b/src/Guid.ts
@@ -125,7 +125,7 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
         if (seed !== null && seed instanceof (Guid)) {
             let merged = '';
             for (let i = 0; i < 36; i++) {
-                const l = '0123456789ABCDEF'.indexOf(seed.value.charAt(i));
+                const l = '0123456789ABCDEF'.indexOf(seed.#value.charAt(i));
                 const r = '0123456789ABCDEF'.indexOf(v.charAt(i));
                 merged += l === -1 || r === -1 ? v.charAt(i) : '0123456789ABCDEF'.charAt(l ^ r);
             }

--- a/src/Guid.ts
+++ b/src/Guid.ts
@@ -11,45 +11,45 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      *          you will normally use Guid.newGuid() or Guid.parse(string).
      */
     private constructor(value: string) {
-        this.value = value;
+        this.#value = value;
     }
 
     /**
      * The underlying value.
      */
-    private readonly value: string;
+    readonly #value: string;
 
     /** 
      * Returns a string that represents the current GUID.
      */
     public toString(): string {
-        return this.value;
+        return this.#value;
     }
     /** 
      * Returns a string that represents the current GUID.
      */
     public format(f?: string): string {
         switch (f) {
-            case 'B': return '{' + this.value + '}';
-            case 'b': return '{' + this.value.toLowerCase() + '}';
-            case 'S': return this.value.replace(/-/g, '');
-            case 's': return this.value.replace(/-/g, '').toLowerCase();
-            case 'l': return this.value.toLowerCase();
-            case 'U': case 'u': default: return this.value;
+            case 'B': return '{' + this.#value + '}';
+            case 'b': return '{' + this.#value.toLowerCase() + '}';
+            case 'S': return this.#value.replace(/-/g, '');
+            case 's': return this.#value.replace(/-/g, '').toLowerCase();
+            case 'l': return this.#value.toLowerCase();
+            case 'U': case 'u': default: return this.#value;
         }
     }
     /** 
      * Returns a JSON representation of the GUID.
      */
     public toJSON(): string {
-        return this.value;
+        return this.#value;
     }
 
     /**
      * Returns the version of the GUID.
      */
     public get version(): number {
-        return parseInt(this.value.slice(14, 15));
+        return parseInt(this.#value.slice(14, 15));
     }
 
     /**
@@ -58,7 +58,7 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
      */
     public equals(other: unknown): boolean {
         return other instanceof (Guid)
-            && other.value === this.value;
+            && other.#value === this.#value;
     }
 
     /**

--- a/src/InternationalBankAccountNumber.ts
+++ b/src/InternationalBankAccountNumber.ts
@@ -7,33 +7,33 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
      *          you will normally use InternationalBankAccountNumber.parse(string).
      */
     private constructor(value: string) {
-        this.value = value;
+        this.#value= value;
     }
 
     /**
      * The underlying value.
      */
-    private readonly value;
+    readonly #value;
 
     /**
      * Gets the country of the IBAN.
      */
     public get country() {
-        return this.value.slice(0, 2);
+        return this.#value.slice(0, 2);
     }
 
     /**
      * Gets the length of the IBAN.
      */
     public get length() {
-        return this.value.length;
+        return this.#value.length;
     }
 
     /** 
     * Returns a string that represents the current IBAN.
     */
     public toString(): string {
-        return this.value;
+        return this.#value;
     }
 
     /** 
@@ -51,8 +51,8 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
     */
     public format(f?: string): string {
         switch (f) {
-            case 'u': case 'm': return this.value.toLowerCase();
-            case 'U': case 'M': return this.value;
+            case 'u': case 'm': return this.#value.toLowerCase();
+            case 'U': case 'M': return this.#value;
             case 'f': return this.humanReadable(' ').toLowerCase();
             case 'F': return this.humanReadable(' ');
             case 'h': return this.humanReadable(' ').toLowerCase();
@@ -61,7 +61,7 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
     }
 
     private humanReadable(ch: string): string {
-        return this.value.replace(/.{4}(?!$)/g, '$&' + ch);
+        return this.#value.replace(/.{4}(?!$)/g, '$&' + ch);
     }
 
     /**
@@ -70,14 +70,14 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
      */
     public equals(other: unknown): boolean {
         return other instanceof (InternationalBankAccountNumber)
-            && other.value === this.value;
+            && other.#value === this.#value;
     }
 
     /** 
      * Returns a JSON representation of the IBAN.
      */
     public toJSON(): string {
-        return this.value;
+        return this.#value;
     }
 
     /**

--- a/src/PostalCode.ts
+++ b/src/PostalCode.ts
@@ -33,26 +33,26 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     *          PostalCode use PostalCode.parse(string).
     */
     private constructor(value: string) {
-        this.value = value;
+        this.#value = value;
     }
 
     /**
      * The underlying value.
      */
-    private readonly value: string;
+    readonly #value: string;
 
     /**
      * Gets the length of the postal code.
      */
     public get length() {
-        return this.value.length;
+        return this.#value.length;
     }
 
     /** 
      * Returns a string that represents the current postal code.
      */
     public toString(): string {
-        return this.value;
+        return this.#value;
     }
 
     /** 
@@ -61,16 +61,16 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     public format(f: string): string {
         const info = PostalCode.Infos.get(f);
 
-        return info?.isValid(this.value)
-            ? info.format(this.value)
-            : this.value;
+        return info?.isValid(this.#value)
+            ? info.format(this.#value)
+            : this.#value;
     }
 
     /** 
      * Returns a JSON representation of the postal code.
      */
     public toJSON(): string {
-        return this.value;
+        return this.#value;
     }
 
     /**
@@ -79,7 +79,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      */
     public equals(other: unknown): boolean {
         return other instanceof (PostalCode)
-            && other.value === this.value;
+            && other.#value === this.#value;
     }
 
     /**
@@ -89,7 +89,7 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
      */
     public isValid(country: string): boolean {
         const info = PostalCode.Infos.get(country);
-        return info?.isValid(this.value) === true;
+        return info?.isValid(this.#value) === true;
     }
 
     /**


### PR DESCRIPTION
In general I'm not sure if I would like to use the `#` field operator, but hiding the underlying field for string based SVO's is key. So also making them private in the ECMAScript (runtime) context, rather then only within the TypeScript (design-time) context makes sense.

See https://github.com/microsoft/TypeScript/issues/31670