### PR TITLE
Make IFormattable generic

### DIFF
--- a/packages/qowaiv/src/Guid.ts
+++ b/packages/qowaiv/src/Guid.ts
@@ -1,9 +1,11 @@
 import { Svo, Unparsable } from '.';
 
+type GuidFormat = 'B' | 'b' | 'S' | 's' | 'l' | 'U' | 'u';
+
 /**
  * Represents a Globally unique identifier (GUID).
  */
-export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
+export class Guid implements IEquatable, IFormattable<GuidFormat>, IJsonStringifyable {
 
     /**
      * @constructor
@@ -27,8 +29,17 @@ export class Guid implements IEquatable, IFormattable, IJsonStringifyable {
     }
     /** 
      * Returns a string that represents the current GUID.
+     * @param {string} f the format to apply.
+     * @remarks The formats:
+     * B: Surrounded by { }.
+     * b: Lowercased, surrounded by { }.
+     * S: Stripped from its dashes.
+     * s: Lowercased, stripped from its dashes.
+     * l: Lowercased.
+     * U: Uppercased.
+     * u: Uppercased.
      */
-    public format(f?: string): string {
+    public format(f?: GuidFormat): string {
         switch (f) {
             case 'B': return '{' + this.#value + '}';
             case 'b': return '{' + this.#value.toLowerCase() + '}';

--- a/packages/qowaiv/src/Interfaces/IFormattable.ts
+++ b/packages/qowaiv/src/Interfaces/IFormattable.ts
@@ -1,17 +1,17 @@
 /**
  * Provides functionality to format the value of an object into a string representation.
  */
-interface IFormattable {
+interface IFormattable<TOptions> {
     /**
      * Returns a string that represents the object.
      * @returns string.
      */
     toString(): string;
 
-    /**
+     /**
      * Returns a formatted string that represents the object.
-     * @param {string} f The format that this describes the formatting.
+     * @param options An object that contains one or more properties that specify comparison options.
      * @returns formatted string.
      */
-    format(f: string): string;
+     format(options?: TOptions): string;
 }

--- a/packages/qowaiv/src/Interfaces/ILocalizable.ts
+++ b/packages/qowaiv/src/Interfaces/ILocalizable.ts
@@ -1,7 +1,7 @@
 /**
  * Provides functionality to format the value of an object into a string representation.
  */
-interface ILocalizable<TOption> {
+interface ILocalizable<TOptions> {
     /**
      * Returns a string that represents the object.
      * @returns string.
@@ -14,5 +14,5 @@ interface ILocalizable<TOption> {
      * @param options An object that contains one or more properties that specify comparison options.
      * @returns formatted string.
      */
-     format(locales?: string | string[], options?: TOption): string;
+     format(locales?: string | string[], options?: TOptions): string;
 }

--- a/packages/qowaiv/src/InternationalBankAccountNumber.ts
+++ b/packages/qowaiv/src/InternationalBankAccountNumber.ts
@@ -1,6 +1,8 @@
 import { Svo, Unparsable } from '.';
 
-export class InternationalBankAccountNumber implements IEquatable, IFormattable, IJsonStringifyable {
+type InternationalBankAccountNumberFormat = 'm' |'M' |'u' |'U' |'h' |'H' |'f' |'F';
+
+export class InternationalBankAccountNumber implements IEquatable, IFormattable<InternationalBankAccountNumberFormat>, IJsonStringifyable {
     /**
      * @constructor
      * @remarks It is the default constructor, for creating an actual IBAN
@@ -49,7 +51,7 @@ export class InternationalBankAccountNumber implements IEquatable, IFormattable,
     * f: as formatted lowercase.
     * F: as formatted uppercase.
     */
-    public format(f?: string): string {
+    public format(f?: InternationalBankAccountNumberFormat): string {
         switch (f) {
             case 'u': case 'm': return this.#value.toLowerCase();
             case 'U': case 'M': return this.#value;

--- a/packages/qowaiv/src/PostalCode.ts
+++ b/packages/qowaiv/src/PostalCode.ts
@@ -25,7 +25,7 @@ class PostalCodeInfo {
 /**
  * Represents a postal code.
  */
-export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable {
+export class PostalCode implements IEquatable, IFormattable<string>, IJsonStringifyable {
 
     /**
     * @constructor
@@ -58,8 +58,8 @@ export class PostalCode implements IEquatable, IFormattable, IJsonStringifyable 
     /** 
      * Returns a string that represents the current postal code.
      */
-    public format(f: string): string {
-        const info = PostalCode.#Infos.get(f);
+    public format(f?: string): string {
+        const info = f ? PostalCode.#Infos.get(f) : undefined;
 
         return info?.isValid(this.#value)
             ? info.format(this.#value)


### PR DESCRIPTION
For `ILocalizable` we came up with a generic to specify the format options. This is now also applied to `IFormattable`.

For `InternationalBankAccountNumber`, and `Guid` we were able to limit the allowed format strings.