### PR TITLE
Implement DateOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ const leap = DateOnly.isLeapYear(1988);      // true
 const days = DateOnly.daysPerMonth(1988, 2); // 29
 
 const dateTime = date.toDateTime(); // 2017-06-11T:00:00:00Z
+
+const format = date.format('nl', { dateStyle: 'full' }); // zondag 11 juni 2017
 ```
 
 ### GUID
@@ -139,13 +141,13 @@ const Model = z.object({
     name: z.string(), // Zod defined type
 	email: q.email(), // Qowaiv-Zod defined type
 });
-````
+```
 
 ### Email Address
 For email validation, the following features are available:
 
 ``` TypeScript
-q.email();             // required email address
+q.email();            // required email address
 q.email().ipBased();  // required email address including IP=based
 q.email().optional(); // optional email address
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ if (svo instanceof (Unparsable)) {
 
 ## Types
 
+### Clock
+The clock provides a testable set of functions that return the current time/date.
+
+``` TypeScript
+const now = Clock.now();
+const today = Clock.today();
+
+// updates the generator.
+Clock.generator = () => new Date(2025, 09, 10);
+```
+
 ### Date (only)
 Represents a date (only) within the range of 0001-01-01 and 9999-12-31.
 Contrary to JavaScript's `Date`, the month component is 1-based, just like the

--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ if (svo instanceof (Unparsable)) {
 
 ## Types
 
+### Date (only)
+Represents a date (only) within the range of 0001-01-01 and 9999-12-31.
+Contrary to JavaScript's `Date`, the month component is 1-based, just like the
+year and the day (of month).
+
+``` TypeScript
+const date = DateOnly.parse('2017-06-11');
+const epoch = date.unixEpoch;     // total seconds since 1970-01-01
+const dayOfMonth = date.day;      // 11
+const dayOfWeek = date.dayOfWeek; // 0, Sunday
+const dayOfYear = date.dayOfYear; // 162
+
+const next = date.addYears(10);   // 2027-06-11
+const next = date.addMonths(-3);  // 2017-03-11
+const next = date.addDays(40);    // 2017-07-21
+
+const leap = DateOnly.isLeapYear(1988);      // true
+const days = DateOnly.daysPerMonth(1988, 2); // 29
+
+const dateTime = date.toDateTime(); // 2017-06-11T:00:00:00Z
+```
+
 ### GUID
 Represents a Globally Unique Identifier (GUID). 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2487,7 +2487,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@qowaiv/qowaiv": "0.0.3",
+        "@qowaiv/qowaiv": "^0.0.4",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -2495,6 +2495,12 @@
         "typescript": "^5.7.3",
         "vitest": "^3.0.5"
       }
+    },
+    "packages/qowaiv-zod/node_modules/@qowaiv/qowaiv": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@qowaiv/qowaiv/-/qowaiv-0.0.4.tgz",
+      "integrity": "sha512-pM86+pZm/ND7aZRk9KZT2jk5yx3WSviv5oYgS2Dc8CCeEKUCKGZFQymVHlVpbhL0mYJubgju0vNceP+MaNSvoQ==",
+      "license": "MIT"
     }
   }
 }

--- a/packages/qowaiv/specs/Clock.spec.ts
+++ b/packages/qowaiv/specs/Clock.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { Clock, DateOnly } from '../src';
+
+describe("Clock: ", () => {
+
+
+    it("Clock now can be updated", () => {
+
+        Clock.generator = () => new Date(2017, 6, 11);
+        const now = Clock.today();
+
+        expect(now).toStrictEqual(new DateOnly(2017, 6, 11));
+    });
+});

--- a/packages/qowaiv/specs/Clock.spec.ts
+++ b/packages/qowaiv/specs/Clock.spec.ts
@@ -3,7 +3,6 @@ import { Clock, DateOnly } from '../src';
 
 describe("Clock: ", () => {
 
-
     it("Clock now can be updated", () => {
 
         Clock.generator = () => new Date(2017, 6, 11);

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -4,10 +4,11 @@ import { DateOnly } from '../src';
 describe('Date-time', () => {
 
     test.each([
-        [new DateOnly(1753, 1, 1), -6847804800000],
-        [new DateOnly(1970, 1, 1), 0],
-        [new DateOnly(1970, 1, 2), 86400000],
-        [new DateOnly(1970, 1, 3), 172800000],
+        [new DateOnly(1753,  1,  1), -6847804800000],
+        [new DateOnly(1969, 12, 31), -86400000],
+        [new DateOnly(1970,  1,  1), 0],
+        [new DateOnly(1970,  1,  2), 86400000],
+        [new DateOnly(1970,  1,  3), 172800000],
         [new DateOnly(9999, 12, 31), 253402214400000],
     ])('unix time stamp for %0 is %1', (date, expected) => {
         const timestamp = Date.UTC(date.year, date.month, date.day);
@@ -80,6 +81,48 @@ describe('Date-only', () => {
             expect(next).toStrictEqual(new DateOnly(1988, 2, 29));
         });
 
+        it('days guards min value', () => {
+            expect(() => DateOnly.minValue.addDays(-1)).throws();
+        });
+
+        it('days guards max value', () => {
+            expect(() => DateOnly.maxValue.addDays(+1)).throws();
+        });
+
+         it('0 days returns a new date-only', () =>{
+            const curr = new DateOnly(2017, 6, 11);
+            const next = curr.addDays(0);
+            expect(next).toStrictEqual(new DateOnly(2017, 6, 11));
+            expect(next).not.toBe(curr);
+        });
+
+        it('-1 days returns a new date-only', () =>{
+            const curr = new DateOnly(2017, 6, 11);
+            const next = curr.addDays(-1);
+            expect(next).toStrictEqual(new DateOnly(2017, 6, 10));
+            expect(next).not.toBe(curr);
+        });
+
+         it('+1 days returns a new date-only', () =>{
+            const curr = new DateOnly(2017, 6, 11);
+            const next = curr.addDays(+1);
+            expect(next).toStrictEqual(new DateOnly(2017, 6, 12));
+            expect(next).not.toBe(curr);
+        });
+
+          it('+1 days returns a new date-only in a leap year', () =>{
+            const curr = new DateOnly(1988, 2, 29);
+            const next = curr.addDays(+1);
+            expect(next).toStrictEqual(new DateOnly(1988, 3, 1));
+            expect(next).not.toBe(curr);
+        });
+
+         it('days returns a new date-only', () =>{
+            const curr = new DateOnly(2017, 6, 11);
+            const next = curr.addDays(3650);
+            expect(next).toStrictEqual(new DateOnly(2027, 6, 9));
+            expect(next).not.toBe(curr);
+        });
     });
 
     it('toDateTime() returns date equvilent of dates from 1970 and up', () => {

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -75,8 +75,42 @@ describe('Date-only', () => {
         [new DateOnly(2025,  8, 22), fri],
         [new DateOnly(2025, 10,  3), fri],
         [new DateOnly(1979, 12,  1), sat],
-    ])('getDayOfWeek() of the week returns %0', (date, day) => {
+    ])('getDayOfWeek() returns %0', (date, day) => {
         expect(date.getDayOfWeek()).toBe(day);
     });
 
+    // values from: https://nsidc.org/data/user-resources/help-center/day-year-doy-calendar
+    test.each([
+        [new DateOnly(2025,  1,  1),   1],
+        [new DateOnly(2025,  2,  3),  34],
+        [new DateOnly(2025,  3,  5),  64],
+        [new DateOnly(2025,  4,  7),  97],
+        [new DateOnly(2025,  5,  9), 129],
+        [new DateOnly(2025,  6, 11), 162],
+        [new DateOnly(2025,  7, 13), 194],
+        [new DateOnly(2025,  8, 15), 227],
+        [new DateOnly(2025,  9, 17), 260],
+        [new DateOnly(2025, 10, 19), 292],
+        [new DateOnly(2025, 11, 21), 325],
+        [new DateOnly(2025, 12, 31), 365],
+    ])('getDayOfYear() of the week for non leap years returns %0', (date, day) => {
+        expect(date.getDayOfYear()).toBe(day);
+    });
+
+    test.each([
+        [new DateOnly(2024,  1,  1),   1],
+        [new DateOnly(2024,  2,  3),  34],
+        [new DateOnly(2024,  3,  5),  65],
+        [new DateOnly(2024,  4,  7),  98],
+        [new DateOnly(2024,  5,  9), 130],
+        [new DateOnly(2024,  6, 11), 163],
+        [new DateOnly(2024,  7, 13), 195],
+        [new DateOnly(2024,  8, 15), 228],
+        [new DateOnly(2024,  9, 17), 261],
+        [new DateOnly(2024, 10, 19), 293],
+        [new DateOnly(2024, 11, 21), 326],
+        [new DateOnly(2024, 12, 31), 366],
+    ])('getDayOfYear() of the week for leap years returns %0', (date, day) => {
+        expect(date.getDayOfYear()).toBe(day);
+    });
 });

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -3,10 +3,13 @@ import { DateOnly } from '../src';
 
 describe('Date-only', () => {
 
-    it('getDay() returns 0-based day of the week', () => {
-        const date = new DateOnly(2017, 6, 11);
-        expect(date.getDay()).toBe(0);
-    });
+    const sun = 0;
+    const mon = 1;
+    const tue = 2;
+    const wed = 3;
+    const thu = 4;
+    const fri = 5;
+    const sat = 6;
 
     it('getDate() returns 1-based day of the month', () => {
         const date = new DateOnly(2017, 6, 11);
@@ -60,4 +63,20 @@ describe('Date-only', () => {
         const date = new DateOnly(2017, 6, 11);
         expect(date.equals(other)).toBe(false);
     });
+    
+    test.each([
+        [new DateOnly(2017,  6, 11), sun],
+        [new DateOnly(2000,  9, 10), sun],
+        [new DateOnly(1848, 12, 25), mon],
+        [new DateOnly(2001,  9, 11), tue],
+        [new DateOnly(2023,  2, 14), tue],
+        [new DateOnly(1969,  4, 30), wed],
+        [new DateOnly(1900,  5, 24), thu],
+        [new DateOnly(2025,  8, 22), fri],
+        [new DateOnly(2025, 10,  3), fri],
+        [new DateOnly(1979, 12,  1), sat],
+    ])('getDayOfWeek() of the week returns %0', (date, day) => {
+        expect(date.getDayOfWeek()).toBe(day);
+    });
+
 });

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -41,6 +41,47 @@ describe('Date-only', () => {
         expect(date.getYear()).toBe(2017);
     });
 
+    describe('add', () => {
+
+        it('years guards min value', () =>{
+            expect(() => DateOnly.minValue.addYears(-1)).throws();
+        });
+
+        it('years guards max value', () =>{
+            expect(() => DateOnly.maxValue.addYears(+1)).throws();
+        });
+
+        it('years returns a new date-only', () =>{
+            const curr = new DateOnly(2017, 6, 11);
+            const next = curr.addYears(8);
+
+            expect(next).toStrictEqual(new DateOnly(2025, 6, 11));
+            expect(next).not.toBe(curr);
+        });
+
+        it('months guards min value', () => {
+            expect(() => DateOnly.minValue.addMonths(-1)).throws();
+        });
+
+        it('months guards max value', () => {
+            expect(() => DateOnly.maxValue.addMonths(+1)).throws();
+        });
+
+         it('months returns a new date-only', () =>{
+            const curr = new DateOnly(2017, 6, 11);
+            const next = curr.addMonths(8);
+            expect(next).toStrictEqual(new DateOnly(2018, 2, 11));
+            expect(next).not.toBe(curr);
+        });
+
+        it('months returns a new date-only guarding the day of the month', () =>{
+            const curr = new DateOnly(1988, 5, 31);
+            const next = curr.addMonths(-3);
+            expect(next).toStrictEqual(new DateOnly(1988, 2, 29));
+        });
+
+    });
+
     it('toDateTime() returns date equvilent of dates from 1970 and up', () => {
         const date = new DateOnly(2017, 6, 11);
         const time = new Date(Date.UTC(2017, 6 - 1, 11));

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -11,6 +11,14 @@ describe('Date-only', () => {
     const fri = 5;
     const sat = 6;
 
+    it('minValue is 0001-01-01', () => {
+        expect(DateOnly.minValue).toStrictEqual(new DateOnly(1, 1, 1));
+    });
+
+    it('maxValue is 9999-12-31', () => {
+        expect(DateOnly.maxValue).toStrictEqual(new DateOnly(9999, 12, 31));
+    });
+
     it('getDate() returns 1-based day of the month', () => {
         const date = new DateOnly(2017, 6, 11);
         expect(date.getDate()).toBe(11);

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it, test } from 'vitest';
 import { DateOnly } from '../src';
 
-describe('Date-only', () => {
+describe('Date-time', () => {
 
-    const sun = 0;
-    const mon = 1;
-    const tue = 2;
-    const wed = 3;
-    const thu = 4;
-    const fri = 5;
-    const sat = 6;
+    test.each([
+        [new DateOnly(1753, 1, 1), -6847804800000],
+        [new DateOnly(1970, 1, 1), 0],
+        [new DateOnly(1970, 1, 2), 86400000],
+        [new DateOnly(1970, 1, 3), 172800000],
+        [new DateOnly(9999, 12, 31), 253402214400000],
+    ])('unix time stamp for %0 is %1', (date, expected) => {
+        const timestamp = Date.UTC(date.year, date.month, date.day);
+        expect(timestamp).toBe(expected);
+        expect(date.unixEpoch).toBe(expected);
+    });
+});
+
+describe('Date-only', () => {
 
     it('minValue is 0001-01-01', () => {
         expect(DateOnly.minValue).toStrictEqual(new DateOnly(1, 1, 1));
@@ -21,7 +28,7 @@ describe('Date-only', () => {
 
     it('getDate() returns 1-based day of the month', () => {
         const date = new DateOnly(2017, 6, 11);
-        expect(date.getDate()).toBe(11);
+        expect(date.getDay()).toBe(11);
     });
 
     it('getMonth() returns 1-based month of the year', () => {
@@ -38,11 +45,6 @@ describe('Date-only', () => {
         const date = new DateOnly(2017, 6, 11);
         const time = new Date(Date.UTC(2017, 6 - 1, 11));
         expect(date.toDateTime()).toStrictEqual(time);
-    });
-
-    it('toDateTime() is undefined for dates before 1970', () => {
-        const date = new DateOnly(1969, 12, 31);
-        expect(date.toDateTime()).toBeUndefined();
     });
 
     it("equals is true for same date-only's", () => {
@@ -67,58 +69,110 @@ describe('Date-only', () => {
         new Date(2017, 5, 10),
         null,
         undefined,
-    ])('equals is false for %other', (other) => {
+    ])('equals is false for %0', (other) => {
         const date = new DateOnly(2017, 6, 11);
         expect(date.equals(other)).toBe(false);
     });
-    
-    test.each([
-        [new DateOnly(2017,  6, 11), sun],
-        [new DateOnly(2000,  9, 10), sun],
-        [new DateOnly(1848, 12, 25), mon],
-        [new DateOnly(2001,  9, 11), tue],
-        [new DateOnly(2023,  2, 14), tue],
-        [new DateOnly(1969,  4, 30), wed],
-        [new DateOnly(1900,  5, 24), thu],
-        [new DateOnly(2025,  8, 22), fri],
-        [new DateOnly(2025, 10,  3), fri],
-        [new DateOnly(1979, 12,  1), sat],
-    ])('getDayOfWeek() returns %0', (date, day) => {
-        expect(date.getDayOfWeek()).toBe(day);
+
+    describe('days per', () => {
+
+        test.each([1, 3, 5, 7, 8, 10, 12])
+            ('month is 31 for Jan, Mar, Jul, Aug, Oct, and Dec', (month) => {
+
+                expect(DateOnly.daysPerMonth(2025, month)).toBe(31);
+            });
+
+        test.each([4, 6, 9, 11])
+            ('month is 30 for Apr, Jun, Sep, and Nov', (month) => {
+
+                expect(DateOnly.daysPerMonth(2025, month)).toBe(30);
+            });
+
+        it('month is 28 for Feb not in a leap year', () => {
+            expect(DateOnly.daysPerMonth(2025, 2)).toBe(28);
+        });
+
+        it('month is 29 for Feb in a leap year', () => {
+            expect(DateOnly.daysPerMonth(2024, 2)).toBe(29);
+        });
     });
 
-    // values from: https://nsidc.org/data/user-resources/help-center/day-year-doy-calendar
-    test.each([
-        [new DateOnly(2025,  1,  1),   1],
-        [new DateOnly(2025,  2,  3),  34],
-        [new DateOnly(2025,  3,  5),  64],
-        [new DateOnly(2025,  4,  7),  97],
-        [new DateOnly(2025,  5,  9), 129],
-        [new DateOnly(2025,  6, 11), 162],
-        [new DateOnly(2025,  7, 13), 194],
-        [new DateOnly(2025,  8, 15), 227],
-        [new DateOnly(2025,  9, 17), 260],
-        [new DateOnly(2025, 10, 19), 292],
-        [new DateOnly(2025, 11, 21), 325],
-        [new DateOnly(2025, 12, 31), 365],
-    ])('getDayOfYear() of the week for non leap years returns %0', (date, day) => {
-        expect(date.getDayOfYear()).toBe(day);
+    describe('day of', () => {
+        const sun = 0;
+        const mon = 1;
+        const tue = 2;
+        const wed = 3;
+        const thu = 4;
+        const fri = 5;
+        const sat = 6;
+
+        test.each([
+            [new DateOnly(2017, 6, 11), sun],
+            [new DateOnly(2000, 9, 10), sun],
+            [new DateOnly(1848, 12, 25), mon],
+            [new DateOnly(2001, 9, 11), tue],
+            [new DateOnly(2023, 2, 14), tue],
+            [new DateOnly(1969, 4, 30), wed],
+            [new DateOnly(1900, 5, 24), thu],
+            [new DateOnly(1970, 1, 1), thu],
+            [new DateOnly(2025, 8, 22), fri],
+            [new DateOnly(2025, 10, 3), fri],
+            [new DateOnly(1979, 12, 1), sat],
+        ])('week returns %1 for %0', (date, day) => {
+            expect(date.dayOfWeek).toBe(day);
+        });
+
+        // values from: https://nsidc.org/data/user-resources/help-center/day-year-doy-calendar
+        test.each([
+            [new DateOnly(2025, 1, 1), 1],
+            [new DateOnly(2025, 2, 3), 34],
+            [new DateOnly(2025, 3, 5), 64],
+            [new DateOnly(2025, 4, 7), 97],
+            [new DateOnly(2025, 5, 9), 129],
+            [new DateOnly(2025, 6, 11), 162],
+            [new DateOnly(2025, 7, 13), 194],
+            [new DateOnly(2025, 8, 15), 227],
+            [new DateOnly(2025, 9, 17), 260],
+            [new DateOnly(2025, 10, 19), 292],
+            [new DateOnly(2025, 11, 21), 325],
+            [new DateOnly(2025, 12, 31), 365],
+        ])('year for non leap years returns %1 for %0', (date, day) => {
+            expect(date.dayOfYear).toBe(day);
+        });
+
+        test.each([
+            [new DateOnly(2024, 1, 1), 1],
+            [new DateOnly(2024, 2, 3), 34],
+            [new DateOnly(2024, 3, 5), 65],
+            [new DateOnly(2024, 4, 7), 98],
+            [new DateOnly(2024, 5, 9), 130],
+            [new DateOnly(2024, 6, 11), 163],
+            [new DateOnly(2024, 7, 13), 195],
+            [new DateOnly(2024, 8, 15), 228],
+            [new DateOnly(2024, 9, 17), 261],
+            [new DateOnly(2024, 10, 19), 293],
+            [new DateOnly(2024, 11, 21), 326],
+            [new DateOnly(2024, 12, 31), 366],
+        ])('year for leap years returns %0', (date, day) => {
+            expect(date.dayOfYear).toBe(day);
+        });
     });
 
-    test.each([
-        [new DateOnly(2024,  1,  1),   1],
-        [new DateOnly(2024,  2,  3),  34],
-        [new DateOnly(2024,  3,  5),  65],
-        [new DateOnly(2024,  4,  7),  98],
-        [new DateOnly(2024,  5,  9), 130],
-        [new DateOnly(2024,  6, 11), 163],
-        [new DateOnly(2024,  7, 13), 195],
-        [new DateOnly(2024,  8, 15), 228],
-        [new DateOnly(2024,  9, 17), 261],
-        [new DateOnly(2024, 10, 19), 293],
-        [new DateOnly(2024, 11, 21), 326],
-        [new DateOnly(2024, 12, 31), 366],
-    ])('getDayOfYear() of the week for leap years returns %0', (date, day) => {
-        expect(date.getDayOfYear()).toBe(day);
+    describe('Leap years', () => {
+
+        test.each([1901, 1990, 2003])
+            ('Years not divisible by 4 are not', (year) => {
+                expect(DateOnly.isLeapYear(year)).toBe(false);
+            });
+
+        test.each([1900, 1800])
+            ('Years divisible by 100 but not 400 are not', (year) => {
+                expect(DateOnly.isLeapYear(year)).toBe(false);
+            });
+
+        test.each([1988, 2000, 2024])
+            ('Years divisible by 4 (not divisible by 100 except divisible by 400) are', (year) => {
+                expect(DateOnly.isLeapYear(year)).toBe(true);
+            });
     });
 });

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -23,9 +23,26 @@ describe('Date-only', () => {
         expect(date.getYear()).toBe(2017);
     });
 
-    it('equals is true for same dates', () => {
+    it('toDateTime() returns date equvilent of dates from 1970 and up', () => {
+        const date = new DateOnly(2017, 6, 11);
+        const time = new Date(Date.UTC(2017, 6 - 1, 11));
+        expect(date.toDateTime()).toStrictEqual(time);
+    });
+
+    it('toDateTime() is undefined for dates before 1970', () => {
+        const date = new DateOnly(1969, 12, 31);
+        expect(date.toDateTime()).toBeUndefined();
+    });
+
+    it("equals is true for same date-only's", () => {
         const date = new DateOnly(2017, 6, 11);
         expect(date.equals(new DateOnly(2017, 6, 11))).toBe(true);
+    });
+
+    it("equals is true for same date-times's", () => {
+        const date = new DateOnly(2017, 6, 11);
+        const othr = new Date(Date.UTC(2017, 6 - 1, 11));
+        expect(date.equals(othr)).toBe(true);
     });
 
     test.each([
@@ -36,7 +53,7 @@ describe('Date-only', () => {
         new DateOnly(2017, 7, 11),
         new DateOnly(2017, 6, 10),
         new DateOnly(2017, 6, 12),
-        new Date(2017, 5, 11),
+        new Date(2017, 5, 10),
         null,
         undefined,
     ])('equals is false for %other', (other) => {

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, test } from 'vitest';
+import { DateOnly } from '../src';
+
+describe('Date-only', () => {
+
+    it('getDay() returns 0-based day of the week', () => {
+        const date = new DateOnly(2017, 6, 11);
+        expect(date.getDay()).toBe(0);
+    });
+
+    it('getDate() returns 1-based day of the month', () => {
+        const date = new DateOnly(2017, 6, 11);
+        expect(date.getDate()).toBe(11);
+    });
+
+    it('getMonth() returns 1-based month of the year', () => {
+        const date = new DateOnly(2017, 6, 11);
+        expect(date.getMonth()).toBe(6);
+    });
+
+    it('getYear() returns 1-based year', () => {
+        const date = new DateOnly(2017, 6, 11);
+        expect(date.getYear()).toBe(2017);
+    });
+
+    it('equals is true for same dates', () => {
+        const date = new DateOnly(2017, 6, 11);
+        expect(date.equals(new DateOnly(2017, 6, 11))).toBe(true);
+    });
+
+    test.each([
+        42,
+        new DateOnly(2016, 6, 11),
+        new DateOnly(2018, 6, 11),
+        new DateOnly(2017, 5, 11),
+        new DateOnly(2017, 7, 11),
+        new DateOnly(2017, 6, 10),
+        new DateOnly(2017, 6, 12),
+        new Date(2017, 5, 11),
+        null,
+        undefined,
+    ])('equals is false for %other', (other) => {
+        const date = new DateOnly(2017, 6, 11);
+        expect(date.equals(other)).toBe(false);
+    });
+});

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -171,10 +171,6 @@ describe('Date-only', () => {
             expect(new DateOnly(2017, 6, 11).toString()).toBe('2017-06-11');
         });
 
-        it('dd/MM/yyyy for unspecified', () => {
-            expect(new DateOnly(2017, 6, 11).format()).toBe('11/06/2017');
-        });
-
         it('Supports date style full', () => {
             expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'full' })).toBe('zondag 11 juni 2017');
         });

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -108,7 +108,7 @@ describe('Date-only', () => {
             expect(() => DateOnly.maxValue.addMonths(+1)).throws();
         });
 
-         it('months returns a new date-only', () => {
+        it('months returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addMonths(8);
             expect(next).toStrictEqual(new DateOnly(2018, 2, 11));
@@ -165,7 +165,36 @@ describe('Date-only', () => {
         });
     });
 
-    it('toDateTime() returns date equvilent of dates from 1970 and up', () => {
+     describe('format', () => {
+        
+        it('toString() is conform ISO', () => {
+            expect(new DateOnly(2017, 6, 11).toString()).toBe('2017-06-11');
+        });
+
+        it('dd/MM/yyyy for unspecified', () => {
+            expect(new DateOnly(2017, 6, 11).format()).toBe('11/06/2017');
+        });
+
+        it('Supports date style full', () => {
+            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'full' })).toBe('zondag 11 juni 2017');
+        });
+
+         it('Supports date style long', () => {
+            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'long' })).toBe('11 juni 2017');
+        });
+
+
+        it('Supports date style medium', () => {
+            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'medium' })).toBe('11 jun 2017');
+        });
+
+        it('Supports date style short', () => {
+            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'short' })).toBe('11-06-2017');
+        });
+
+     });
+
+    it('toDateTime() returns date equvilent of dates.', () => {
         const date = new DateOnly(2017, 6, 11);
         const time = new Date(Date.UTC(2017, 6 - 1, 11));
         expect(date.toDateTime()).toStrictEqual(time);

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -194,7 +194,7 @@ describe('Date-only', () => {
 
      });
 
-    it('toDateTime() returns date equvilent of dates.', () => {
+    it('toDateTime() returns date equivalent of dates.', () => {
         const date = new DateOnly(2017, 6, 11);
         const time = new Date(Date.UTC(2017, 6 - 1, 11));
         expect(date.toDateTime()).toStrictEqual(time);

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -1,19 +1,29 @@
 import { describe, expect, it, test } from 'vitest';
 import { DateOnly } from '../src';
+import { Rnd } from './_rnd';
 
 describe('Date-time', () => {
 
     test.each([
-        [new DateOnly(1753,  1,  1), -6847804800000],
-        [new DateOnly(1969, 12, 31), -86400000],
-        [new DateOnly(1970,  1,  1), 0],
-        [new DateOnly(1970,  1,  2), 86400000],
-        [new DateOnly(1970,  1,  3), 172800000],
+        [new DateOnly(1308,  4, 16), -20881584000000],
+        [new DateOnly(1753,  1,  1),  -6847804800000],
+        [new DateOnly(1969, 12, 31),       -86400000],
+        [new DateOnly(1970,  1,  1),               0],
+        [new DateOnly(1970,  1,  2),        86400000],
+        [new DateOnly(1970,  1,  3),       172800000],
         [new DateOnly(9999, 12, 31), 253402214400000],
-    ])('unix time stamp for %0 is %1', (date, expected) => {
-        const timestamp = Date.UTC(date.year, date.month, date.day);
-        expect(timestamp).toBe(expected);
+    ])('unix time stamp for %s is %', (date, expected) => {
+        const timestamp = Date.UTC(date.year, date.month - 1, date.day);
+
         expect(date.unixEpoch).toBe(expected);
+        expect(timestamp).toBe(expected);
+    });
+
+    test.each(Rnd.nextDates(100))
+    ('%s: DateOnly.dayOfWeek equals Date.getDay() ', (date) => {
+
+        const dateOnly = DateOnly.fromDate(date);
+        expect(dateOnly.dayOfWeek).toBe(date.getUTCDay());
     });
 });
 
@@ -27,32 +37,62 @@ describe('Date-only', () => {
         expect(DateOnly.maxValue).toStrictEqual(new DateOnly(9999, 12, 31));
     });
 
-    it('getDate() returns 1-based day of the month', () => {
+    it('day returns 1-based day of the month', () => {
         const date = new DateOnly(2017, 6, 11);
-        expect(date.getDay()).toBe(11);
+        expect(date.day).toBe(11);
     });
 
-    it('getMonth() returns 1-based month of the year', () => {
+    it('month returns 1-based month of the year', () => {
         const date = new DateOnly(2017, 6, 11);
-        expect(date.getMonth()).toBe(6);
+        expect(date.month).toBe(6);
     });
 
-    it('getYear() returns 1-based year', () => {
+    it('year returns 1-based year', () => {
         const date = new DateOnly(2017, 6, 11);
-        expect(date.getYear()).toBe(2017);
+        expect(date.year).toBe(2017);
+    });
+
+    describe('parse', () => {
+
+        test.each([
+            ' ',
+            '\t',
+            '',
+            null,
+            undefined,
+            ])('parses %s as undefined', (s) => {
+                const svo = DateOnly.parse(s!);
+                expect(svo).toBeUndefined();
+            });
+
+        it('throws for invalid input', () => {
+            expect(() => DateOnly.parse('not a date')).throws('Not a valid date');
+        });
+
+        it('parses yyyy-MM-dd', () => {
+            expect(DateOnly.parse('2017-06-11')).toStrictEqual(new DateOnly(2017, 6, 11));
+        });
+
+        it('parses yyy-M-d', () => {
+            expect(DateOnly.parse('217-6-3')).toStrictEqual(new DateOnly(217, 6, 3));
+        });
+
+        it('parses standard date-time string format', () => {
+            expect(DateOnly.parse('2017-06-11T06:15:00Z')).toStrictEqual(new DateOnly(2017, 6, 11));
+        });
     });
 
     describe('add', () => {
 
-        it('years guards min value', () =>{
+        it('years guards min value', () => {
             expect(() => DateOnly.minValue.addYears(-1)).throws();
         });
 
-        it('years guards max value', () =>{
+        it('years guards max value', () => {
             expect(() => DateOnly.maxValue.addYears(+1)).throws();
         });
 
-        it('years returns a new date-only', () =>{
+        it('years returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addYears(8);
 
@@ -68,14 +108,14 @@ describe('Date-only', () => {
             expect(() => DateOnly.maxValue.addMonths(+1)).throws();
         });
 
-         it('months returns a new date-only', () =>{
+         it('months returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addMonths(8);
             expect(next).toStrictEqual(new DateOnly(2018, 2, 11));
             expect(next).not.toBe(curr);
         });
 
-        it('months returns a new date-only guarding the day of the month', () =>{
+        it('months returns a new date-only guarding the day of the month', () => {
             const curr = new DateOnly(1988, 5, 31);
             const next = curr.addMonths(-3);
             expect(next).toStrictEqual(new DateOnly(1988, 2, 29));
@@ -89,35 +129,35 @@ describe('Date-only', () => {
             expect(() => DateOnly.maxValue.addDays(+1)).throws();
         });
 
-         it('0 days returns a new date-only', () =>{
+         it('0 days returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addDays(0);
             expect(next).toStrictEqual(new DateOnly(2017, 6, 11));
             expect(next).not.toBe(curr);
         });
 
-        it('-1 days returns a new date-only', () =>{
+        it('-1 days returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addDays(-1);
             expect(next).toStrictEqual(new DateOnly(2017, 6, 10));
             expect(next).not.toBe(curr);
         });
 
-         it('+1 days returns a new date-only', () =>{
+         it('+1 days returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addDays(+1);
             expect(next).toStrictEqual(new DateOnly(2017, 6, 12));
             expect(next).not.toBe(curr);
         });
 
-          it('+1 days returns a new date-only in a leap year', () =>{
+          it('+1 days returns a new date-only in a leap year', () => {
             const curr = new DateOnly(1988, 2, 29);
             const next = curr.addDays(+1);
             expect(next).toStrictEqual(new DateOnly(1988, 3, 1));
             expect(next).not.toBe(curr);
         });
 
-         it('days returns a new date-only', () =>{
+         it('days returns a new date-only', () => {
             const curr = new DateOnly(2017, 6, 11);
             const next = curr.addDays(3650);
             expect(next).toStrictEqual(new DateOnly(2027, 6, 9));
@@ -153,7 +193,7 @@ describe('Date-only', () => {
         new Date(2017, 5, 10),
         null,
         undefined,
-    ])('equals is false for %0', (other) => {
+    ])('equals is false for %s', (other) => {
         const date = new DateOnly(2017, 6, 11);
         expect(date.equals(other)).toBe(false);
     });

--- a/packages/qowaiv/specs/Guard.spec.ts
+++ b/packages/qowaiv/specs/Guard.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, test } from 'vitest';
+import { Guard } from '../src';
+
+describe("Guard: ", () => {
+    test.each([
+        -900719925474099,
+        -10000,
+        -1,
+        0,
+        1,
+        42,
+        23545235,
+        900719925474099,
+    ])('int guards integer value %0', (val) =>{
+        expect(Guard.int(val)).toBe(val);
+    });
+
+    test.each([
+        '',
+        Number.NaN,
+        Number.NEGATIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+        Number.EPSILON,
+        0.11,
+        Math.PI,
+        Math.E,
+    ])('int does not guard non integer value %0', (val) =>{
+        expect(() => Guard.int(val)).toThrow();
+    });
+
+    test.each([
+        1,
+        2,
+        3,
+        4,
+    ])('int guards integer value %0 when in range', (val) =>{
+        expect(Guard.int(val, 1, 4)).toBe(val);
+    });
+
+    test.each([
+        -1,
+        0,
+        5,
+        6,
+    ])('int does no guard integer value %0 out of range', (val) =>{
+        expect(() => Guard.int(val, 1, 4)).toThrow();
+    });
+});

--- a/packages/qowaiv/specs/Rnd.spec.ts
+++ b/packages/qowaiv/specs/Rnd.spec.ts
@@ -3,7 +3,7 @@ import { Rnd } from './_rnd';
 
 describe('Rnd', () => {
 
-    it('nextInt() has inclusive bounderies', () => {
+    it('nextInt() has inclusive boundaries', () => {
 
         const counts = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 

--- a/packages/qowaiv/specs/Rnd.spec.ts
+++ b/packages/qowaiv/specs/Rnd.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { Rnd } from './_rnd';
+
+describe('Rnd', () => {
+
+    it('nextInt() has inclusive bounderies', () => {
+
+        const counts = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        for (let i = 0; i < 1000; i++) {
+            counts[Rnd.nextInt(2, 8)]++;
+        }
+
+        expect(counts[0]).toBe(0);
+        expect(counts[1]).toBe(0);
+        expect(counts[9]).toBe(0);
+        expect(counts[2]).not.toBe(0);
+        expect(counts[3]).not.toBe(0);
+        expect(counts[4]).not.toBe(0);
+        expect(counts[5]).not.toBe(0);
+        expect(counts[6]).not.toBe(0);
+        expect(counts[7]).not.toBe(0);
+        expect(counts[8]).not.toBe(0);
+    });
+});

--- a/packages/qowaiv/specs/_rnd.ts
+++ b/packages/qowaiv/specs/_rnd.ts
@@ -1,0 +1,50 @@
+import { DateOnly } from "../src";
+
+/**
+ * (Pseudo) random generator.
+ */
+export class Rnd {
+
+    /**
+     * Gets a specified number of random @see Date 's.
+     */
+    public static nextDates(count: number): ReadonlyArray<Date> {
+        return Rnd.nextDateOnlys(count).map(d => {
+
+            const h = Rnd.nextInt(0, 23);
+            const M = Rnd.nextInt(0, 59);
+            const s = Rnd.nextInt(0, 59);
+            const ss = Rnd.nextInt(0, 1000);
+            const e = Date.UTC(d.year, d.month - 1, d.day, h, M, s, ss);
+            let date = new Date(e);
+            // 2k issue with Date.
+            date.setUTCFullYear(d.year);
+            return date;
+        });
+    }
+
+    /**
+     * Gets a specified number of random @see DateOnly 's.
+     */
+    public static nextDateOnlys(count: number): ReadonlyArray<DateOnly> {
+        const dates = new Array<DateOnly>();
+
+        for (let i = 0; i < count; i++) {
+            const y = Rnd.nextInt(1, 9999);
+            const m = Rnd.nextInt(1, 12);
+            const d = Rnd.nextInt(1, DateOnly.daysPerMonth(y, m));
+            dates.push(new DateOnly(y, m, d));
+        }
+        return dates;
+    }
+
+    /**
+     * Gets a random integer number.
+     */
+    public static nextInt(min?: number, max?: number) {
+        min = min ?? 0;
+        max = max ?? (Number.MAX_SAFE_INTEGER - 1);
+        let rnd = Math.random() * (1 + max - min);
+        return Math.floor(rnd + min);
+    }
+}

--- a/packages/qowaiv/src/Clock.ts
+++ b/packages/qowaiv/src/Clock.ts
@@ -1,0 +1,22 @@
+import { DateOnly } from "./DateOnly";
+
+export class Clock {
+
+    public static generator = () => new Date();
+
+    /**
+     * @returns now as date-time.
+     */
+    public static now(): Date {
+        var now = Clock.generator();
+        return now;
+    }
+
+    /**
+     * @returns today as a date-only.
+     */
+    public static today(): DateOnly {
+        var now = Clock.now();
+        return new DateOnly(now.getFullYear(), now.getMonth(), now.getDate());
+    }
+}

--- a/packages/qowaiv/src/Clock.ts
+++ b/packages/qowaiv/src/Clock.ts
@@ -1,5 +1,8 @@
 import { DateOnly } from "./DateOnly";
 
+/**
+ * Static (testable) clock.
+ */
 export class Clock {
 
     public static generator = () => new Date();

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -50,14 +50,12 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
 
     /**
      * @returns the day of the week (0 – 6) for the specified date-only.
-     * @remarks Uses Tomohiko Sakamoto's method @see https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week
      */
     public getDayOfWeek(): number {
-        const y = this.month < 2 ? this.year - 1 : this.year;
-        const days = this.day
-            + y // shift per year
-            + [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4][this.month] // shifts per month
-            + ~~(y/4) // extra shift for leap years
+        const y = this.year - 1;
+        const days = this.getDayOfYear()
+            + y
+            + ~~(y/4)
             + ~~(y/400)
             - ~~(y/100);
         return days % 7;
@@ -81,13 +79,30 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
             : new Date(Date.UTC(this.year, this.month, this.day));
     }
 
-     /** 
+    /** 
+     * @returns a string that represents the current postal code.
+     */
+    public toString(): string {
+        return `${DateOnly.#pad(this.getYear(), 4)}-${DateOnly.#pad(this.getMonth())}-${DateOnly.#pad(this.getDate())}`;
+    }
+
+    /** 
      * @returns a JSON representation of the date-only.
      */
     public toJSON(): string {
-        return `${this.getYear()}-${this.getMonth()}-${this.getDate()}`;
+        return this.toString();
     }
 
+    /**
+     * @remarks String.ProtoType.padStart() is not available.
+     */
+    static #pad(n: number, padding?: number) : string{
+        let s = n.toString();
+        while(s.length < (padding ?? 2)){
+            s = '0'+s;
+        }
+        return s;
+    }
     /**
      * @returns true if other is a date representing the same value.
      */

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -52,27 +52,38 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns the day of the week (0 – 6) for the specified date-only.
      */
     public getDay(): number{
-        return this.asDate().getDay();
+        // TODO: implement self to ensure working in dates before 1970
+        return this.toDateTime()!.getUTCDay();
     }
 
     /**
-     * @returns the specified date-only as a date-time.
+     * @returns the specified date-only as a date-time for dates starting at 1970-01-01.
      */
-    public asDate(): Date {
-        return new Date(this.year, this.month, this.day);
+    public toDateTime(): Date | undefined {
+        return this.year < 1970
+            ? undefined
+            : new Date(Date.UTC(this.year, this.month, this.day));
     }
 
-    /** @inheritdoc */
+     /** 
+     * @returns a JSON representation of the date-only.
+     */
     public toJSON(): string {
         return `${this.getYear()}-${this.getMonth()}-${this.getDate()}`;
     }
 
-    /** @inheritdoc */
+    /**
+     * @returns true if other is a date representing the same value.
+     */
     public equals(other: unknown): boolean {
-         return other instanceof(DateOnly)
-         && this.year === other.year
-         && this.month === other.month
-         && this.day === other.day;
+        return (other instanceof(DateOnly)
+            && this.year === other.year
+            && this.month === other.month
+            && this.day === other.day)
+        || (other instanceof(Date)
+            && this.year === other.getUTCFullYear()
+            && this.month === other.getUTCMonth()
+            && this.day === other.getUTCDate());
     }
 
     /**

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -1,4 +1,4 @@
-import { Unparsable } from '.';
+import {  Guard, Unparsable } from '.';
 
 export class DateOnly implements IEquatable, IJsonStringifyable {
 
@@ -12,16 +12,21 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      */
     public static readonly maxValue = new DateOnly(9999, 12, 31);
 
+    static readonly #daysPerYear = 365;
+    static readonly #daysTo1970 = 719162;
+    static readonly #secondsPerDay = 86400000;
+
     /**
      * Creates a new date-only.
-     * @param year 1 based year
-     * @param month 1 based month
-     * @param day  1 based day
+     * @param year 1-based (1 - 9999) year
+     * @param month 1-based (1 - 12) month
+     * @param day  1-based (1 - 31) day
      */
     constructor(year: number, month: number, day: number) {
         this.year = year;
         this.month = month - 1;
-        this.day = day;
+        // TODO: guard leads to TypeError: Cannot read properties of undefined.
+        this.day = day;// Guard.int(day, 1, DateOnly.daysPerMonth(year, month));
     }
 
     /**
@@ -54,27 +59,37 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
     /**
      * @returns the  day of the month (1 – 31) for the specified date-only.
      */
-    public getDate(): number {
+    public getDay(): number {
         return this.day;
+    }
+
+    /**
+     * @returns the UNIX epoch for the specified date-only.
+     * @remarks the number of seconds since 1970-01-01.
+     */
+    public get unixEpoch(): number {
+        const y = this.year - 1;
+        const day = this.dayOfYear
+            + y * DateOnly.#daysPerYear
+            + ~~(y / 4)
+            + ~~(y / 400)
+            - ~~(y / 100);
+
+        return (day - DateOnly.#daysTo1970 - 1) * DateOnly.#secondsPerDay;
     }
 
     /**
      * @returns the day of the week (0 – 6) for the specified date-only.
      */
-    public getDayOfWeek(): number {
-        const y = this.year - 1;
-        const days = this.getDayOfYear()
-            + y
-            + ~~(y/4)
-            + ~~(y/400)
-            - ~~(y/100);
+    public get dayOfWeek(): number {
+        const days = this.unixEpoch / DateOnly.#secondsPerDay + DateOnly.#daysTo1970 + 1;
         return days % 7;
     }
 
     /**
      * @returns The day of the year (1 - 366) for the specified date-only.
      */
-    public getDayOfYear(): number {
+    public get dayOfYear(): number {
         return this.day
             + [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334][this.month] // days per month
             + (this.month >= 2 && DateOnly.isLeapYear(this.year) ? 1 : 0);
@@ -83,17 +98,15 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
     /**
      * @returns the specified date-only as a date-time for dates starting at 1970-01-01.
      */
-    public toDateTime(): Date | undefined {
-        return this.year < 1970
-            ? undefined
-            : new Date(Date.UTC(this.year, this.month, this.day));
+    public toDateTime(): Date {
+        return new Date(this.unixEpoch);
     }
 
     /** 
      * @returns a string that represents the current postal code.
      */
     public toString(): string {
-        return `${DateOnly.#pad(this.getYear(), 4)}-${DateOnly.#pad(this.getMonth())}-${DateOnly.#pad(this.getDate())}`;
+        return `${DateOnly.#pad(this.getYear(), 4)}-${DateOnly.#pad(this.getMonth())}-${DateOnly.#pad(this.getDay())}`;
     }
 
     /** 
@@ -106,33 +119,49 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
     /**
      * @remarks String.ProtoType.padStart() is not available.
      */
-    static #pad(n: number, padding?: number) : string{
+    static #pad(n: number, padding?: number): string {
         let s = n.toString();
-        while(s.length < (padding ?? 2)){
-            s = '0'+s;
+        while (s.length < (padding ?? 2)) {
+            s = '0' + s;
         }
         return s;
     }
+
     /**
      * @returns true if other is a date representing the same value.
      */
     public equals(other: unknown): boolean {
-        return (other instanceof(DateOnly)
+        return (other instanceof (DateOnly)
             && this.year === other.year
             && this.month === other.month
             && this.day === other.day)
-        || (other instanceof(Date)
-            && this.year === other.getUTCFullYear()
-            && this.month === other.getUTCMonth()
-            && this.day === other.getUTCDate());
+            || (other instanceof (Date)
+                && this.year === other.getUTCFullYear()
+                && this.month === other.getUTCMonth()
+                && this.day === other.getUTCDate());
     }
 
     /**
      * @param year The year to check.
      * @returns true if the year is a leap year.
      */
-    public static isLeapYear(year: number) : boolean{
+    public static isLeapYear(year: number): boolean {
+        Guard.int(year, 1, 9999);
         return !(year & 3 || year & 15 && !(year % 25))
+    }
+
+    /**
+     * @param year The year to check.
+     * @param month The month to check.
+     * @returns the total days for the specified year/month.
+     */
+    public static daysPerMonth(year: number, month: number){
+        if (month === 2) {
+            return  DateOnly.isLeapYear(year) ? 29 : 28;
+        }
+        else {
+            return [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][Guard.int(month, 1, 12)];
+        }
     }
 
     /**

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -3,6 +3,16 @@ import { Unparsable } from '.';
 export class DateOnly implements IEquatable, IJsonStringifyable {
 
     /**
+     * The mimimum value of date-only (0001-01-01).
+     */
+    public static readonly minValue = new DateOnly(1, 1, 1);
+
+    /**
+     * The maxium value of date-only (9999-12-31).
+     */
+    public static readonly maxValue = new DateOnly(9999, 12, 31);
+
+    /**
      * Creates a new date-only.
      * @param year 1 based year
      * @param month 1 based month

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -96,6 +96,30 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
     }
 
     /**
+     * Adds the specified number of years to the specified date-only.
+     * @param years The years to add to the specified date-only.
+     * @returns a new instance of a date-only.
+     */
+    public addYears(years: number): DateOnly {
+        // TODO: leave guaring to the ctor.
+        const year = Guard.int(this.year + years, 1, 9999);
+        return new DateOnly(year, this.getMonth(), this.day);
+    }
+
+    /**
+     * Adds the specified number of months to the specified date-only.
+     * @param months The months to add to the specified date-only.
+     * @returns a new instance of a date-only.
+     */
+    public addMonths(months: number): DateOnly {
+        const ms = this.year * 12 + this.month + Guard.int(months);
+        const year = ~~(ms / 12);
+        const month = (ms % 12) + 1; 
+        const day = Math.min(DateOnly.daysPerMonth(year, month), this.day);
+        return new DateOnly(year, month, day);
+    }
+
+    /**
      * @returns the specified date-only as a date-time for dates starting at 1970-01-01.
      */
     public toDateTime(): Date {
@@ -156,6 +180,7 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns the total days for the specified year/month.
      */
     public static daysPerMonth(year: number, month: number){
+        Guard.int(year, 1, 9999);
         if (month === 2) {
             return  DateOnly.isLeapYear(year) ? 29 : 28;
         }

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -1,0 +1,100 @@
+import { Unparsable } from '.';
+
+export class DateOnly implements IEquatable, IJsonStringifyable {
+
+    /**
+     * Creates a new date-only.
+     * @param year 1 based year
+     * @param month 1 based month
+     * @param day  1 based day
+     */
+    constructor(year: number, month: number, day: number) {
+        this.year = year;
+        this.month = month - 1;
+        this.day = day;
+    }
+
+    /**
+     * The year component (1 based).
+     */
+    readonly year: number = 1;
+    /**
+     * The month component (0 based).
+     */
+    readonly month: number = 0;
+    /**
+     * The day component (1 based).
+     */
+    readonly day: number = 1;
+
+    /**
+     * @returns the year (4 digits for 4-digit years) fpr the specified date-only.
+     */
+    public getYear(): number {
+        return this.year;
+    }
+
+    /**
+     * @returns the month (1 – 12) for the specified date-only.
+     */
+    public getMonth(): number {
+        return this.month + 1;
+    }
+
+    /**
+     * @returns the  day of the month (1 – 31) for the specified date-only.
+     */
+    public getDate(): number {
+        return this.day;
+    }
+
+    /**
+     * @returns the day of the week (0 – 6) for the specified date-only.
+     */
+    public getDay(): number{
+        return this.asDate().getDay();
+    }
+
+    /**
+     * @returns the specified date-only as a date-time.
+     */
+    public asDate(): Date {
+        return new Date(this.year, this.month, this.day);
+    }
+
+    /** @inheritdoc */
+    public toJSON(): string {
+        return `${this.getYear()}-${this.getMonth()}-${this.getDate()}`;
+    }
+
+    /** @inheritdoc */
+    public equals(other: unknown): boolean {
+         return other instanceof(DateOnly)
+         && this.year === other.year
+         && this.month === other.month
+         && this.day === other.day;
+    }
+
+    /**
+     * Parses a date-only string.
+     * @param {string} s A string containing date to convert.
+     * @returns {DateOnly} A GUID if valid, otherwise throws.
+     */
+    public static parse(s: string | null | undefined): DateOnly | undefined {
+        const svo = DateOnly.tryParse(s);
+
+        if (svo instanceof (Unparsable)) {
+            throw svo;
+        }
+        return svo;
+    }
+
+    /**
+     * Tries to parse a date-only string.
+     * @param {string} s A string containing GUID to convert.
+     * @returns {DateOnly} A date if valid, otherwise unparsable.
+     */
+    public static tryParse(s: string | null | undefined): DateOnly | Unparsable | undefined {
+        return new Unparsable('Not a valid date', s);
+    }
+}

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -50,10 +50,17 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
 
     /**
      * @returns the day of the week (0 – 6) for the specified date-only.
+     * @remarks Uses Tomohiko Sakamoto's method @see https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week
      */
-    public getDay(): number{
-        // TODO: implement self to ensure working in dates before 1970
-        return this.toDateTime()!.getUTCDay();
+    public getDayOfWeek(): number {
+        const y = this.month < 2 ? this.year - 1 : this.year;
+        const days = this.day
+            + y // shift per year
+            + [0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4][this.month] // shifts per month
+            + ~~(y/4) // extra shift for leap years
+            + ~~(y/400)
+            - ~~(y/100);
+        return days % 7;
     }
 
     /**

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -64,6 +64,15 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
     }
 
     /**
+     * @returns The day of the year (1 - 366) for the specified date-only.
+     */
+    public getDayOfYear(): number {
+        return this.day
+            + [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334][this.month] // days per month
+            + (this.month >= 2 && DateOnly.isLeapYear(this.year) ? 1 : 0);
+    }
+
+    /**
      * @returns the specified date-only as a date-time for dates starting at 1970-01-01.
      */
     public toDateTime(): Date | undefined {
@@ -91,6 +100,14 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
             && this.year === other.getUTCFullYear()
             && this.month === other.getUTCMonth()
             && this.day === other.getUTCDate());
+    }
+
+    /**
+     * @param year The year to check.
+     * @returns true if the year is a leap year.
+     */
+    public static isLeapYear(year: number) : boolean{
+        return !(year & 3 || year & 15 && !(year % 25))
     }
 
     /**

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -1,6 +1,6 @@
 import { Guard, Svo, Unparsable } from '.';
 
-export class DateOnly implements IEquatable, IJsonStringifyable {
+export class DateOnly implements IEquatable, ILocalizable<DateOnlyFormat>, IJsonStringifyable {
 
     /**
      * The mimimum value of date-only (0001-01-01).
@@ -117,10 +117,21 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
     }
 
     /** 
-     * @returns a string that represents the current postal code.
+     * @returns a string that represents the current date-only.
      */
     public toString(): string {
         return `${DateOnly.#pad(this.year, 4)}-${DateOnly.#pad(this.month)}-${DateOnly.#pad(this.day)}`;
+    }
+
+    /**
+     * Returns a formatted string that represents the date.
+     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+     * @param options An object that contains one or more properties that specify comparison options.
+     * @returns formatted string.
+     */
+     public format(locales?: string | string[], options?: DateOnlyFormat): string {
+        const date = this.toDateTime();
+        return date.toLocaleDateString(locales, options);
     }
 
     /** 

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -8,7 +8,7 @@ export class DateOnly implements IEquatable, ILocalizable<DateOnlyFormat>, IJson
     public static readonly minValue = new DateOnly(1, 1, 1);
 
     /**
-     * The maxium value of date-only (9999-12-31).
+     * The maximum value of date-only (9999-12-31).
      */
     public static readonly maxValue = new DateOnly(9999, 12, 31);
 

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -1,4 +1,4 @@
-import { Guard, Unparsable } from '.';
+import { Guard, Svo, Unparsable } from '.';
 
 export class DateOnly implements IEquatable, IJsonStringifyable {
 
@@ -23,43 +23,22 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      */
     constructor(year: number, month: number, day: number) {
         this.year = Guard.int(year, 1, 9999);
-        this.month = Guard.int(month, 1, 12) - 1;
+        this.month = Guard.int(month, 1, 12);
         this.day = Guard.int(day, 1, DateOnly.daysPerMonth(year, month));
     }
 
     /**
-     * The year component (1 based).
+     * The year component (1-based).
      */
-    readonly year: number = 1;
+    public readonly year: number = 1;
     /**
-     * The month component (0 based).
+     * The month component (1-based).
      */
-    readonly month: number = 0;
+    public readonly month: number = 1;
     /**
-     * The day component (1 based).
+     * The day component (1-based).
      */
-    readonly day: number = 1;
-
-    /**
-     * @returns the year (4 digits for 4-digit years) fpr the specified date-only.
-     */
-    public getYear(): number {
-        return this.year;
-    }
-
-    /**
-     * @returns the month (1 – 12) for the specified date-only.
-     */
-    public getMonth(): number {
-        return this.month + 1;
-    }
-
-    /**
-     * @returns the  day of the month (1 – 31) for the specified date-only.
-     */
-    public getDay(): number {
-        return this.day;
-    }
+    public readonly day: number = 1;
 
     /**
      * @returns the UNIX epoch for the specified date-only.
@@ -82,8 +61,8 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      */
     public get dayOfYear(): number {
         return this.day
-            + [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365][this.month] // days per month
-            + (this.month >= 2 && DateOnly.isLeapYear(this.year) ? 1 : 0);
+            + [0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365][this.month] // days per month
+            + (this.month >= 3 && DateOnly.isLeapYear(this.year) ? 1 : 0);
     }
 
     /**
@@ -92,9 +71,7 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns a new instance of a date-only.
      */
     public addYears(years: number): DateOnly {
-        // TODO: leave guaring to the ctor.
-        const year = Guard.int(this.year + years, 1, 9999);
-        return new DateOnly(year, this.getMonth(), this.day);
+        return new DateOnly(this.year + years, this.month, this.day);
     }
 
     /**
@@ -103,7 +80,7 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns a new instance of a date-only.
      */
     public addMonths(months: number): DateOnly {
-        const ms = this.year * 12 + this.month + Guard.int(months);
+        const ms = this.year * 12 + this.month - 1 + Guard.int(months);
         const year = ~~(ms / 12);
         const month = (ms % 12) + 1;
         const day = Math.min(DateOnly.daysPerMonth(year, month), this.day);
@@ -116,7 +93,6 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns a new instance of a date-only.
      */
     public addDays(days: number): DateOnly {
-
         let day = this.#totalDays + Guard.int(days);
 
         // Aproximate the number of years.
@@ -130,8 +106,6 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
             day -= days;
         }
 
-        // TODO: Guard should be done by ctor.
-        Guard.int(day, 1, DateOnly.daysPerMonth(year, month));
         return new DateOnly(year, month, day);
     }
 
@@ -146,7 +120,7 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns a string that represents the current postal code.
      */
     public toString(): string {
-        return `${DateOnly.#pad(this.getYear(), 4)}-${DateOnly.#pad(this.getMonth())}-${DateOnly.#pad(this.getDay())}`;
+        return `${DateOnly.#pad(this.year, 4)}-${DateOnly.#pad(this.month)}-${DateOnly.#pad(this.day)}`;
     }
 
     /** 
@@ -166,7 +140,7 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
             && this.day === other.day)
             || (other instanceof (Date)
                 && this.year === other.getUTCFullYear()
-                && this.month === other.getUTCMonth()
+                && this.month === (other.getUTCMonth() + 1)
                 && this.day === other.getUTCDate());
     }
 
@@ -183,7 +157,7 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @param month The month to check.
      * @returns the total days for the specified year/month.
      */
-    public static daysPerMonth(year: number, month: number) {
+    public static daysPerMonth(year: number, month: number): number {
         Guard.int(year, 1, 9999);
         if (month === 2) {
             return DateOnly.isLeapYear(year) ? 29 : 28;
@@ -191,6 +165,15 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
         else {
             return [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][Guard.int(month, 1, 12)];
         }
+    }
+
+    /**
+     * Creates a date-only based on a date-time.
+     * @param {Date} d The date-time to convert.
+     * @returns {DateOnly} represting the (UTC) date part of the date-time.
+     */
+    public static fromDate(d: Date) : DateOnly {
+        return new DateOnly(d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate());
     }
 
     /**
@@ -213,7 +196,23 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
      * @returns {DateOnly} A date if valid, otherwise unparsable.
      */
     public static tryParse(s: string | null | undefined): DateOnly | Unparsable | undefined {
-        return new Unparsable('Not a valid date', s);
+        if (Svo.isEmpty(s)) {
+            return undefined;
+        }
+        try {
+            const str = s!.trim();
+            const match = str.match(/^(\d{1,4})-(1[0-2]|0?\d)-(3[01]|[0-2]?\d)$/);
+            if (match?.length === 4) {
+                return new DateOnly(Number.parseInt(match[1]),Number.parseInt(match[2]), Number.parseInt(match[3]));
+            }
+
+            const date = new Date(Date.parse(str));
+            if (Number.isFinite(date.getTime())) {
+                return new DateOnly(date.getUTCFullYear(), date.getUTCMonth() +1, date.getUTCDate());
+            }
+        }
+        catch { /* fall trough */}
+        return new Unparsable("Not a valid date", s);
     }
 
     /**
@@ -233,13 +232,6 @@ export class DateOnly implements IEquatable, IJsonStringifyable {
         return ~~(y / 4)
             + ~~(y / 400)
             - ~~(y / 100);
-    }
-
-    /**
-     * @returns the total of days for the specified year.
-     */
-    static #getDaysPerYear(year: number): number {
-        return DateOnly.isLeapYear(year) ? 366 : 365;
     }
 
     /**

--- a/packages/qowaiv/src/Guard.ts
+++ b/packages/qowaiv/src/Guard.ts
@@ -1,0 +1,25 @@
+export class Guard {
+
+    /**
+     * Guards a value to be an integer within the (optional) range.
+     * @param value the value to guard.
+     * @param min the (optional) minimum allowed value
+     * @param max the (optional) maximum allowed value
+     * @returns the value when an integer within the specified range.
+     */
+    public static int(value: unknown, min?: number, max?: number): number {
+        if (typeof (value) !== "number") {
+            throw new Error(`'${value}' is not a number`);
+        }
+        if (!Number.isInteger(value)) {
+            throw new Error(`${value} is not an integer`);
+        }
+        if (min !== undefined && value < min) {
+            throw new Error(`${value} is smaller then ${min}`);
+        }
+        if (max !== undefined && value > max) {
+            throw new Error(`${value} is larger then ${max}`);
+        }
+        return value;
+    }
+}

--- a/packages/qowaiv/src/Guard.ts
+++ b/packages/qowaiv/src/Guard.ts
@@ -4,7 +4,7 @@ export class Guard {
      * Guards a value to be an integer within the (optional) range.
      * @param value the value to guard.
      * @param min the (optional) minimum allowed value
-     * @param max the (optional) maximum allowed value
+     * @param max the (optional) maximum allowed (inclusive) value
      * @returns the value when an integer within the specified range.
      */
     public static int(value: unknown, min?: number, max?: number): number {

--- a/packages/qowaiv/src/Guard.ts
+++ b/packages/qowaiv/src/Guard.ts
@@ -3,7 +3,7 @@ export class Guard {
     /**
      * Guards a value to be an integer within the (optional) range.
      * @param value the value to guard.
-     * @param min the (optional) minimum allowed value
+     * @param min the (optional) minimum allowed (inclusive) value
      * @param max the (optional) maximum allowed (inclusive) value
      * @returns the value when an integer within the specified range.
      */

--- a/packages/qowaiv/src/Interfaces/DateOnlyFormat.ts
+++ b/packages/qowaiv/src/Interfaces/DateOnlyFormat.ts
@@ -1,0 +1,11 @@
+interface DateOnlyFormat {
+    locale?: string | undefined;
+    localeMatcher?: "lookup" | "best fit" | undefined;
+    dateStyle?:  "full" | "long" | "medium" | "short" | undefined;
+    numberingSystem?: string | undefined;
+    weekday?: "long" | "short" | "narrow" | undefined;
+    era?: "long" | "short" | "narrow" | undefined;
+    year?: "numeric" | "2-digit" | undefined;
+    month?: "numeric" | "2-digit" | "long" | "short" | "narrow" | undefined;
+    day?: "numeric" | "2-digit" | undefined;
+}

--- a/packages/qowaiv/src/Interfaces/PercentageFormat.ts
+++ b/packages/qowaiv/src/Interfaces/PercentageFormat.ts
@@ -1,4 +1,5 @@
 interface PercentageFormatOptions {
+    locale?: string | undefined;
     localeMatcher?: "lookup" | "best fit" | undefined;
     symbol?: string | undefined;
     useGrouping?: boolean | undefined;

--- a/packages/qowaiv/src/index.ts
+++ b/packages/qowaiv/src/index.ts
@@ -1,3 +1,5 @@
+export { Clock } from "./Clock";
+export { DateOnly } from "./DateOnly";
 export { EmailAddress } from "./EmailAddress";
 export { Guid } from "./Guid";
 export { InternationalBankAccountNumber } from "./InternationalBankAccountNumber";

--- a/packages/qowaiv/src/index.ts
+++ b/packages/qowaiv/src/index.ts
@@ -1,6 +1,7 @@
 export { Clock } from "./Clock";
 export { DateOnly } from "./DateOnly";
 export { EmailAddress } from "./EmailAddress";
+export { Guard } from "./Guard";
 export { Guid } from "./Guid";
 export { InternationalBankAccountNumber } from "./InternationalBankAccountNumber";
 export { Percentage } from "./Percentage";

--- a/packages/qowaiv/src/index.ts
+++ b/packages/qowaiv/src/index.ts
@@ -1,10 +1,13 @@
-export { Clock } from "./Clock";
+// Helpers
+export { Guard } from "./Guard";
+export { Svo } from "./Svo";
+export { Unparsable } from "./Unparsable";
+// SVO's
 export { DateOnly } from "./DateOnly";
 export { EmailAddress } from "./EmailAddress";
-export { Guard } from "./Guard";
 export { Guid } from "./Guid";
 export { InternationalBankAccountNumber } from "./InternationalBankAccountNumber";
 export { Percentage } from "./Percentage";
 export { PostalCode } from "./PostalCode";
-export { Svo } from "./Svo";
-export { Unparsable } from "./Unparsable";
+// Utility
+export { Clock } from "./Clock";


### PR DESCRIPTION
An implementation that should basically be equal to a `Date` without a time part. However, key differences:
1. immutable
2. `month` is 1-based
3. `year` returns all 4 digits and `GetFullYear()` does not exist
4. `day` returns day of month
5. `dayOfWeek` instead of `getDay()`

Closes #52 