### PR TITLE
Use Object.freeze and interface to define types

### DIFF
--- a/packages/qowaiv/specs/Clock.spec.ts
+++ b/packages/qowaiv/specs/Clock.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { Clock, DateOnly } from '../src';
+import { Clock } from '../src';
+import { create as DateOnly_new } from '../src/DateOnly';
 
 describe("Clock: ", () => {
 
@@ -8,6 +9,6 @@ describe("Clock: ", () => {
         Clock.generator = () => new Date(2017, 6, 11);
         const now = Clock.today();
 
-        expect(now).toStrictEqual(new DateOnly(2017, 6, 11));
+        expect(now).toStrictEqual(DateOnly_new(2017, 6, 11));
     });
 });

--- a/packages/qowaiv/specs/DateOnly.spec.ts
+++ b/packages/qowaiv/specs/DateOnly.spec.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it, test } from 'vitest';
-import { DateOnly } from '../src';
+import { create, parse, fromDate, minValue, maxValue, isLeapYear, daysPerMonth } from '../src/DateOnly';
 import { Rnd } from './_rnd';
 
 describe('Date-time', () => {
 
     test.each([
-        [new DateOnly(1308,  4, 16), -20881584000000],
-        [new DateOnly(1753,  1,  1),  -6847804800000],
-        [new DateOnly(1969, 12, 31),       -86400000],
-        [new DateOnly(1970,  1,  1),               0],
-        [new DateOnly(1970,  1,  2),        86400000],
-        [new DateOnly(1970,  1,  3),       172800000],
-        [new DateOnly(9999, 12, 31), 253402214400000],
+        [create(1308,  4, 16), -20881584000000],
+        [create(1753,  1,  1),  -6847804800000],
+        [create(1969, 12, 31),       -86400000],
+        [create(1970,  1,  1),               0],
+        [create(1970,  1,  2),        86400000],
+        [create(1970,  1,  3),       172800000],
+        [create(9999, 12, 31), 253402214400000],
     ])('unix time stamp for %s is %', (date, expected) => {
         const timestamp = Date.UTC(date.year, date.month - 1, date.day);
 
@@ -22,7 +22,7 @@ describe('Date-time', () => {
     test.each(Rnd.nextDates(100))
     ('%s: DateOnly.dayOfWeek equals Date.getDay() ', (date) => {
 
-        const dateOnly = DateOnly.fromDate(date);
+        const dateOnly = fromDate(date);
         expect(dateOnly.dayOfWeek).toBe(date.getUTCDay());
     });
 });
@@ -30,25 +30,25 @@ describe('Date-time', () => {
 describe('Date-only', () => {
 
     it('minValue is 0001-01-01', () => {
-        expect(DateOnly.minValue).toStrictEqual(new DateOnly(1, 1, 1));
+        expect(minValue).toStrictEqual(create(1, 1, 1));
     });
 
     it('maxValue is 9999-12-31', () => {
-        expect(DateOnly.maxValue).toStrictEqual(new DateOnly(9999, 12, 31));
+        expect(maxValue).toStrictEqual(create(9999, 12, 31));
     });
 
     it('day returns 1-based day of the month', () => {
-        const date = new DateOnly(2017, 6, 11);
+        const date = create(2017, 6, 11);
         expect(date.day).toBe(11);
     });
 
     it('month returns 1-based month of the year', () => {
-        const date = new DateOnly(2017, 6, 11);
+        const date = create(2017, 6, 11);
         expect(date.month).toBe(6);
     });
 
     it('year returns 1-based year', () => {
-        const date = new DateOnly(2017, 6, 11);
+        const date = create(2017, 6, 11);
         expect(date.year).toBe(2017);
     });
 
@@ -61,106 +61,106 @@ describe('Date-only', () => {
             null,
             undefined,
             ])('parses %s as undefined', (s) => {
-                const svo = DateOnly.parse(s!);
+                const svo = parse(s!);
                 expect(svo).toBeUndefined();
             });
 
         it('throws for invalid input', () => {
-            expect(() => DateOnly.parse('not a date')).throws('Not a valid date');
+            expect(() => parse('not a date')).throws('Not a valid date');
         });
 
         it('parses yyyy-MM-dd', () => {
-            expect(DateOnly.parse('2017-06-11')).toStrictEqual(new DateOnly(2017, 6, 11));
+            expect(parse('2017-06-11')).toStrictEqual(create(2017, 6, 11));
         });
 
         it('parses yyy-M-d', () => {
-            expect(DateOnly.parse('217-6-3')).toStrictEqual(new DateOnly(217, 6, 3));
+            expect(parse('217-6-3')).toStrictEqual(create(217, 6, 3));
         });
 
         it('parses standard date-time string format', () => {
-            expect(DateOnly.parse('2017-06-11T06:15:00Z')).toStrictEqual(new DateOnly(2017, 6, 11));
+            expect(parse('2017-06-11T06:15:00Z')).toStrictEqual(create(2017, 6, 11));
         });
     });
 
     describe('add', () => {
 
         it('years guards min value', () => {
-            expect(() => DateOnly.minValue.addYears(-1)).throws();
+            expect(() => minValue.addYears(-1)).throws();
         });
 
         it('years guards max value', () => {
-            expect(() => DateOnly.maxValue.addYears(+1)).throws();
+            expect(() => maxValue.addYears(+1)).throws();
         });
 
         it('years returns a new date-only', () => {
-            const curr = new DateOnly(2017, 6, 11);
+            const curr = create(2017, 6, 11);
             const next = curr.addYears(8);
 
-            expect(next).toStrictEqual(new DateOnly(2025, 6, 11));
+            expect(next.equals(create(2025, 6, 11))).toBe(true);
             expect(next).not.toBe(curr);
         });
 
         it('months guards min value', () => {
-            expect(() => DateOnly.minValue.addMonths(-1)).throws();
+            expect(() => minValue.addMonths(-1)).throws();
         });
 
         it('months guards max value', () => {
-            expect(() => DateOnly.maxValue.addMonths(+1)).throws();
+            expect(() => maxValue.addMonths(+1)).throws();
         });
 
         it('months returns a new date-only', () => {
-            const curr = new DateOnly(2017, 6, 11);
+            const curr = create(2017, 6, 11);
             const next = curr.addMonths(8);
-            expect(next).toStrictEqual(new DateOnly(2018, 2, 11));
+            expect(next).toStrictEqual(create(2018, 2, 11));
             expect(next).not.toBe(curr);
         });
 
         it('months returns a new date-only guarding the day of the month', () => {
-            const curr = new DateOnly(1988, 5, 31);
+            const curr = create(1988, 5, 31);
             const next = curr.addMonths(-3);
-            expect(next).toStrictEqual(new DateOnly(1988, 2, 29));
+            expect(next).toStrictEqual(create(1988, 2, 29));
         });
 
         it('days guards min value', () => {
-            expect(() => DateOnly.minValue.addDays(-1)).throws();
+            expect(() => minValue.addDays(-1)).throws();
         });
 
         it('days guards max value', () => {
-            expect(() => DateOnly.maxValue.addDays(+1)).throws();
+            expect(() => maxValue.addDays(+1)).throws();
         });
 
          it('0 days returns a new date-only', () => {
-            const curr = new DateOnly(2017, 6, 11);
+            const curr = create(2017, 6, 11);
             const next = curr.addDays(0);
-            expect(next).toStrictEqual(new DateOnly(2017, 6, 11));
+            expect(next).toStrictEqual(create(2017, 6, 11));
             expect(next).not.toBe(curr);
         });
 
         it('-1 days returns a new date-only', () => {
-            const curr = new DateOnly(2017, 6, 11);
+            const curr = create(2017, 6, 11);
             const next = curr.addDays(-1);
-            expect(next).toStrictEqual(new DateOnly(2017, 6, 10));
+            expect(next).toStrictEqual(create(2017, 6, 10));
             expect(next).not.toBe(curr);
         });
 
          it('+1 days returns a new date-only', () => {
-            const curr = new DateOnly(2017, 6, 11);
+            const curr = create(2017, 6, 11);
             const next = curr.addDays(+1);
-            expect(next).toStrictEqual(new DateOnly(2017, 6, 12));
+            expect(next).toStrictEqual(create(2017, 6, 12));
             expect(next).not.toBe(curr);
         });
 
           it('+1 days returns a new date-only in a leap year', () => {
-            const curr = new DateOnly(1988, 2, 29);
+            const curr = create(1988, 2, 29);
             const next = curr.addDays(+1);
-            expect(next).toStrictEqual(new DateOnly(1988, 3, 1));
+            expect(next).toStrictEqual(create(1988, 3, 1));
             expect(next).not.toBe(curr);
         });
 
          it('days returns a new date-only', () => {
-            const curr = new DateOnly(2017, 6, 11);
+            const curr = create(2017, 6, 11);
             const next = curr.addDays(3650);
-            expect(next).toStrictEqual(new DateOnly(2027, 6, 9));
+            expect(next).toStrictEqual(create(2027, 6, 9));
             expect(next).not.toBe(curr);
         });
     });
@@ -168,58 +168,58 @@ describe('Date-only', () => {
      describe('format', () => {
         
         it('toString() is conform ISO', () => {
-            expect(new DateOnly(2017, 6, 11).toString()).toBe('2017-06-11');
+            expect(create(2017, 6, 11).toString()).toBe('2017-06-11');
         });
 
         it('Supports date style full', () => {
-            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'full' })).toBe('zondag 11 juni 2017');
+            expect(create(2017, 6, 11).format('nl', { dateStyle: 'full' })).toBe('zondag 11 juni 2017');
         });
 
          it('Supports date style long', () => {
-            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'long' })).toBe('11 juni 2017');
+            expect(create(2017, 6, 11).format('nl', { dateStyle: 'long' })).toBe('11 juni 2017');
         });
 
 
         it('Supports date style medium', () => {
-            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'medium' })).toBe('11 jun 2017');
+            expect(create(2017, 6, 11).format('nl', { dateStyle: 'medium' })).toBe('11 jun 2017');
         });
 
         it('Supports date style short', () => {
-            expect(new DateOnly(2017, 6, 11).format('nl', { dateStyle: 'short' })).toBe('11-06-2017');
+            expect(create(2017, 6, 11).format('nl', { dateStyle: 'short' })).toBe('11-06-2017');
         });
 
      });
 
     it('toDateTime() returns date equivalent of dates.', () => {
-        const date = new DateOnly(2017, 6, 11);
+        const date = create(2017, 6, 11);
         const time = new Date(Date.UTC(2017, 6 - 1, 11));
         expect(date.toDateTime()).toStrictEqual(time);
     });
 
     it("equals is true for same date-only's", () => {
-        const date = new DateOnly(2017, 6, 11);
-        expect(date.equals(new DateOnly(2017, 6, 11))).toBe(true);
+        const date = create(2017, 6, 11);
+        expect(date.equals(create(2017, 6, 11))).toBe(true);
     });
 
     it("equals is true for same date-times's", () => {
-        const date = new DateOnly(2017, 6, 11);
+        const date = create(2017, 6, 11);
         const othr = new Date(Date.UTC(2017, 6 - 1, 11));
         expect(date.equals(othr)).toBe(true);
     });
 
     test.each([
         42,
-        new DateOnly(2016, 6, 11),
-        new DateOnly(2018, 6, 11),
-        new DateOnly(2017, 5, 11),
-        new DateOnly(2017, 7, 11),
-        new DateOnly(2017, 6, 10),
-        new DateOnly(2017, 6, 12),
+        create(2016, 6, 11),
+        create(2018, 6, 11),
+        create(2017, 5, 11),
+        create(2017, 7, 11),
+        create(2017, 6, 10),
+        create(2017, 6, 12),
         new Date(2017, 5, 10),
         null,
         undefined,
     ])('equals is false for %s', (other) => {
-        const date = new DateOnly(2017, 6, 11);
+        const date = create(2017, 6, 11);
         expect(date.equals(other)).toBe(false);
     });
 
@@ -228,21 +228,21 @@ describe('Date-only', () => {
         test.each([1, 3, 5, 7, 8, 10, 12])
             ('month is 31 for Jan, Mar, Jul, Aug, Oct, and Dec', (month) => {
 
-                expect(DateOnly.daysPerMonth(2025, month)).toBe(31);
+                expect(daysPerMonth(2025, month)).toBe(31);
             });
 
         test.each([4, 6, 9, 11])
             ('month is 30 for Apr, Jun, Sep, and Nov', (month) => {
 
-                expect(DateOnly.daysPerMonth(2025, month)).toBe(30);
+                expect(daysPerMonth(2025, month)).toBe(30);
             });
 
         it('month is 28 for Feb not in a leap year', () => {
-            expect(DateOnly.daysPerMonth(2025, 2)).toBe(28);
+            expect(daysPerMonth(2025, 2)).toBe(28);
         });
 
         it('month is 29 for Feb in a leap year', () => {
-            expect(DateOnly.daysPerMonth(2024, 2)).toBe(29);
+            expect(daysPerMonth(2024, 2)).toBe(29);
         });
     });
 
@@ -256,54 +256,54 @@ describe('Date-only', () => {
         const sat = 6;
 
         test.each([
-            [new DateOnly(2017, 6, 11), sun],
-            [new DateOnly(2000, 9, 10), sun],
-            [new DateOnly(1848, 12, 25), mon],
-            [new DateOnly(2001, 9, 11), tue],
-            [new DateOnly(2023, 2, 14), tue],
-            [new DateOnly(1969, 4, 30), wed],
-            [new DateOnly(1900, 5, 24), thu],
-            [new DateOnly(1970, 1, 1), thu],
-            [new DateOnly(2025, 8, 22), fri],
-            [new DateOnly(2025, 10, 3), fri],
-            [new DateOnly(1979, 12, 1), sat],
+            [create(2017, 6, 11), sun],
+            [create(2000, 9, 10), sun],
+            [create(1848, 12, 25), mon],
+            [create(2001, 9, 11), tue],
+            [create(2023, 2, 14), tue],
+            [create(1969, 4, 30), wed],
+            [create(1900, 5, 24), thu],
+            [create(1970, 1, 1), thu],
+            [create(2025, 8, 22), fri],
+            [create(2025, 10, 3), fri],
+            [create(1979, 12, 1), sat],
         ])('week returns %1 for %0', (date, day) => {
-            expect(date.dayOfWeek).toBe(day);
+            expect(date.dayOfWeek()).toBe(day);
         });
 
         // values from: https://nsidc.org/data/user-resources/help-center/day-year-doy-calendar
         test.each([
-            [new DateOnly(2025, 1, 1), 1],
-            [new DateOnly(2025, 2, 3), 34],
-            [new DateOnly(2025, 3, 5), 64],
-            [new DateOnly(2025, 4, 7), 97],
-            [new DateOnly(2025, 5, 9), 129],
-            [new DateOnly(2025, 6, 11), 162],
-            [new DateOnly(2025, 7, 13), 194],
-            [new DateOnly(2025, 8, 15), 227],
-            [new DateOnly(2025, 9, 17), 260],
-            [new DateOnly(2025, 10, 19), 292],
-            [new DateOnly(2025, 11, 21), 325],
-            [new DateOnly(2025, 12, 31), 365],
+            [create(2025, 1, 1), 1],
+            [create(2025, 2, 3), 34],
+            [create(2025, 3, 5), 64],
+            [create(2025, 4, 7), 97],
+            [create(2025, 5, 9), 129],
+            [create(2025, 6, 11), 162],
+            [create(2025, 7, 13), 194],
+            [create(2025, 8, 15), 227],
+            [create(2025, 9, 17), 260],
+            [create(2025, 10, 19), 292],
+            [create(2025, 11, 21), 325],
+            [create(2025, 12, 31), 365],
         ])('year for non leap years returns %1 for %0', (date, day) => {
-            expect(date.dayOfYear).toBe(day);
+            expect(date.dayOfYear()).toBe(day);
         });
 
         test.each([
-            [new DateOnly(2024, 1, 1), 1],
-            [new DateOnly(2024, 2, 3), 34],
-            [new DateOnly(2024, 3, 5), 65],
-            [new DateOnly(2024, 4, 7), 98],
-            [new DateOnly(2024, 5, 9), 130],
-            [new DateOnly(2024, 6, 11), 163],
-            [new DateOnly(2024, 7, 13), 195],
-            [new DateOnly(2024, 8, 15), 228],
-            [new DateOnly(2024, 9, 17), 261],
-            [new DateOnly(2024, 10, 19), 293],
-            [new DateOnly(2024, 11, 21), 326],
-            [new DateOnly(2024, 12, 31), 366],
+            [create(2024, 1, 1), 1],
+            [create(2024, 2, 3), 34],
+            [create(2024, 3, 5), 65],
+            [create(2024, 4, 7), 98],
+            [create(2024, 5, 9), 130],
+            [create(2024, 6, 11), 163],
+            [create(2024, 7, 13), 195],
+            [create(2024, 8, 15), 228],
+            [create(2024, 9, 17), 261],
+            [create(2024, 10, 19), 293],
+            [create(2024, 11, 21), 326],
+            [create(2024, 12, 31), 366],
         ])('year for leap years returns %0', (date, day) => {
-            expect(date.dayOfYear).toBe(day);
+            expect(date.dayOfYear()).toBe(day);
         });
     });
 
@@ -311,17 +311,17 @@ describe('Date-only', () => {
 
         test.each([1901, 1990, 2003])
             ('Years not divisible by 4 are not', (year) => {
-                expect(DateOnly.isLeapYear(year)).toBe(false);
+                expect(isLeapYear(year)).toBe(false);
             });
 
         test.each([1900, 1800])
             ('Years divisible by 100 but not 400 are not', (year) => {
-                expect(DateOnly.isLeapYear(year)).toBe(false);
+                expect(isLeapYear(year)).toBe(false);
             });
 
         test.each([1988, 2000, 2024])
             ('Years divisible by 4 (not divisible by 100 except divisible by 400) are', (year) => {
-                expect(DateOnly.isLeapYear(year)).toBe(true);
+                expect(isLeapYear(year)).toBe(true);
             });
     });
 });

--- a/packages/qowaiv/specs/_rnd.ts
+++ b/packages/qowaiv/specs/_rnd.ts
@@ -1,4 +1,4 @@
-import { DateOnly } from "../src";
+import { create as DateOnly_new, daysPerMonth, DateOnly } from "../src/DateOnly";
 
 /**
  * (Pseudo) random generator.
@@ -32,8 +32,8 @@ export class Rnd {
         for (let i = 0; i < count; i++) {
             const y = Rnd.nextInt(1, 9999);
             const m = Rnd.nextInt(1, 12);
-            const d = Rnd.nextInt(1, DateOnly.daysPerMonth(y, m));
-            dates.push(new DateOnly(y, m, d));
+            const d = Rnd.nextInt(1, daysPerMonth(y, m));
+            dates.push(DateOnly_new(y, m, d));
         }
         return dates;
     }

--- a/packages/qowaiv/src/Clock.ts
+++ b/packages/qowaiv/src/Clock.ts
@@ -1,4 +1,4 @@
-import { DateOnly } from "./DateOnly";
+import { create as DateOnly_new, DateOnly } from "./DateOnly";
 
 /**
  * Static (testable) clock.
@@ -20,6 +20,6 @@ export class Clock {
      */
     public static today(): DateOnly {
         var now = Clock.now();
-        return new DateOnly(now.getFullYear(), now.getMonth(), now.getDate());
+        return DateOnly_new(now.getFullYear(), now.getMonth(), now.getDate());
     }
 }

--- a/packages/qowaiv/src/DateOnly.ts
+++ b/packages/qowaiv/src/DateOnly.ts
@@ -1,258 +1,251 @@
 import { Guard, Svo, Unparsable } from '.';
 
-export class DateOnly implements IEquatable, ILocalizable<DateOnlyFormat>, IJsonStringifyable {
-
-    /**
-     * The mimimum value of date-only (0001-01-01).
-     */
-    public static readonly minValue = new DateOnly(1, 1, 1);
-
-    /**
-     * The maximum value of date-only (9999-12-31).
-     */
-    public static readonly maxValue = new DateOnly(9999, 12, 31);
-
-    static readonly #daysTo1970 = 719162;
-    static readonly #secondsPerDay = 86400000;
-        
-    /**
-     * Creates a new date-only.
-     * @param year 1-based (1 - 9999) year
-     * @param month 1-based (1 - 12) month
-     * @param day  1-based (1 - 31) day
-     */
-    constructor(year: number, month: number, day: number) {
-        this.year = Guard.int(year, 1, 9999);
-        this.month = Guard.int(month, 1, 12);
-        this.day = Guard.int(day, 1, DateOnly.daysPerMonth(year, month));
-    }
-
+export interface DateOnly extends IEquatable, ILocalizable<DateOnlyFormat>, IJsonStringifyable {
     /**
      * The year component (1-based).
      */
-    public readonly year: number = 1;
+    readonly year: number;
     /**
      * The month component (1-based).
      */
-    public readonly month: number = 1;
+    readonly month: number;
     /**
      * The day component (1-based).
      */
-    public readonly day: number = 1;
+    readonly day: number;
 
     /**
      * @returns the UNIX epoch for the specified date-only.
      * @remarks the number of seconds since 1970-01-01.
      */
-    public get unixEpoch(): number {
-        return (this.#totalDays - DateOnly.#daysTo1970 - 1) * DateOnly.#secondsPerDay;
-    }
+    unixEpoch(): number;
 
     /**
      * @returns the day of the week (0 – 6) for the specified date-only.
      */
-    public get dayOfWeek(): number {
-        const days = this.unixEpoch / DateOnly.#secondsPerDay + DateOnly.#daysTo1970 + 1;
-        return days % 7;
-    }
+    dayOfWeek(): number;
 
     /**
      * @returns The day of the year (1 - 366) for the specified date-only.
      */
-    public get dayOfYear(): number {
-        return this.day
-            + [0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365][this.month] // days per month
-            + (this.month >= 3 && DateOnly.isLeapYear(this.year) ? 1 : 0);
-    }
+    dayOfYear(): number;
 
     /**
-     * Adds the specified number of years to the specified date-only.
-     * @param years The years to add to the specified date-only.
-     * @returns a new instance of a date-only.
-     */
-    public addYears(years: number): DateOnly {
-        return new DateOnly(this.year + years, this.month, this.day);
-    }
+    * Adds the specified number of years to the specified date-only.
+    * @param years The years to add to the specified date-only.
+    * @returns a new instance of a date-only.
+    */
+    addYears(years: number): DateOnly;
 
     /**
      * Adds the specified number of months to the specified date-only.
      * @param months The months to add to the specified date-only.
      * @returns a new instance of a date-only.
      */
-    public addMonths(months: number): DateOnly {
-        const ms = this.year * 12 + this.month - 1 + Guard.int(months);
-        const year = ~~(ms / 12);
-        const month = (ms % 12) + 1;
-        const day = Math.min(DateOnly.daysPerMonth(year, month), this.day);
-        return new DateOnly(year, month, day);
-    }
+    addMonths(months: number): DateOnly;
 
     /**
      * Adds the specified number of days to the specified date-only.
      * @param days The days to add to the specified date-only.
      * @returns a new instance of a date-only.
      */
-    public addDays(days: number): DateOnly {
-        let day = this.#totalDays + Guard.int(days);
-
-        // Aproximate the number of years.
-        let year = ~~(day / (365.2425)) + 1;
-        day -= (year - 1) * 365 + DateOnly.#getLeapYears(year);
-
-        let month = 0;
-        while (month < 12) {
-            const days = DateOnly.daysPerMonth(year, ++month);
-            if (day < days) break;
-            day -= days;
-        }
-
-        return new DateOnly(year, month, day);
-    }
+    addDays(days: number): DateOnly;
 
     /**
      * @returns the specified date-only as a date-time for dates starting at 1970-01-01.
      */
-    public toDateTime(): Date {
-        return new Date(this.unixEpoch);
+    toDateTime(): Date;
+}
+
+export const minValue = create(1, 1, 1);
+
+export const maxValue = create(9999, 12, 31);
+
+export function create(year: number, month: number, day: number): DateOnly {
+    const daysTo1970 = 719162;
+    const secondsPerDay = 86400000;
+
+    Guard.int(year, 1, 9999);
+    Guard.int(month, 1, 12);
+    Guard.int(day, 1, daysPerMonth(year, month));
+
+    return Object.freeze({
+        year,
+        month,
+        day,
+        unixEpoch,
+        dayOfWeek,
+        dayOfYear,
+        addYears,
+        addMonths,
+        addDays,
+        toDateTime,
+        toString,
+        format,
+        toJSON,
+        equals,
+    } satisfies DateOnly)
+
+    function totalDays(): number {
+        return dayOfYear()
+            + (year - 1) * 365
+            + getLeapYears(year);
     }
 
-    /** 
-     * @returns a string that represents the current date-only.
-     */
-    public toString(): string {
-        return `${DateOnly.#pad(this.year, 4)}-${DateOnly.#pad(this.month)}-${DateOnly.#pad(this.day)}`;
+    function unixEpoch(): number {
+        return (totalDays() - daysTo1970 - 1) * secondsPerDay;
     }
 
-    /**
-     * Returns a formatted string that represents the date.
-     * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
-     * @param options An object that contains one or more properties that specify comparison options.
-     * @returns formatted string.
-     */
-     public format(locales?: string | string[], options?: DateOnlyFormat): string {
-        const date = this.toDateTime();
+    function dayOfWeek(): number {
+        const days = unixEpoch() / secondsPerDay + daysTo1970 + 1;
+        return days % 7;
+    }
+
+    function dayOfYear(): number {
+        return day
+            + [0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365][month] // days per month
+            + (month >= 3 && isLeapYear(year) ? 1 : 0);
+    }
+
+    function addYears(years: number) {
+        return create(year + years, month, day);
+    }
+
+    function addMonths(months: number) {
+        const ms = year * 12 + month - 1 + months;
+        const y = ~~(ms / 12);
+        const m = (ms % 12) + 1;
+        const d = Math.min(daysPerMonth(y, m), day);
+        return create(y, m, d);
+    }
+
+    function addDays(days: number): DateOnly {
+        let d = totalDays() + days;
+
+        // Aproximate the number of years.
+        let y = ~~(d / (365.2425)) + 1;
+        d -= (y - 1) * 365 + getLeapYears(y);
+
+        let m = 0;
+        while (m < 12) {
+            const dpm = daysPerMonth(y, ++m);
+            if (d < dpm) break;
+            d -= dpm;
+        }
+
+        return create(y, m, d);
+    }
+
+    function toDateTime(): Date {
+        return new Date(unixEpoch());
+    }
+
+    function toString(): string {
+        return `${pad(year, 4)}-${pad(month)}-${pad(day)}`;
+    }
+
+    function format(locales?: string | string[], options?: any): string {
+        const date = toDateTime();
         return date.toLocaleDateString(locales, options);
     }
 
-    /** 
-     * @returns a JSON representation of the date-only.
-     */
-    public toJSON(): string {
-        return this.toString();
+    function toJSON(): string {
+        return toString();
     }
 
-    /**
-     * @returns true if other is a date representing the same value.
-     */
-    public equals(other: unknown): boolean {
-        return (other instanceof (DateOnly)
-            && this.year === other.year
-            && this.month === other.month
-            && this.day === other.day)
+    function equals(other: DateOnly): boolean {
+        return (
+            !Svo.isEmpty(other)
+            && year === other.year
+            && month === other.month
+            && day === other.day)
             || (other instanceof (Date)
-                && this.year === other.getUTCFullYear()
-                && this.month === (other.getUTCMonth() + 1)
-                && this.day === other.getUTCDate());
+                && year === other.getUTCFullYear()
+                && month === (other.getUTCMonth() + 1)
+                && day === other.getUTCDate());
     }
+}
 
-    /**
-     * @param year The year to check.
-     * @returns true if the year is a leap year.
-     */
-    public static isLeapYear(year: number): boolean {
-        return !(Guard.int(year, 1, 9999) & 3 || year & 15 && !(year % 25));
+/**
+ * Creates a date-only based on a date-time.
+ * @param {Date} d The date-time to convert.
+ * @returns {DateOnly} represting the (UTC) date part of the date-time.
+ */
+export function fromDate(d: Date): DateOnly {
+    return create(d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate());
+}
+
+/**
+ * Parses a date-only string.
+ * @param {string} s A string containing date to convert.
+ * @returns {DateOnly} A GUID if valid, otherwise throws.
+ */
+export function parse(s: string | null | undefined): DateOnly | undefined {
+    const svo = tryParse(s);
+    if (svo instanceof (Unparsable)) {
+        throw svo;
     }
+    return svo;
+}
 
-    /**
-     * @param year The year to check.
-     * @param month The month to check.
-     * @returns the total days for the specified year/month.
-     */
-    public static daysPerMonth(year: number, month: number): number {
-        Guard.int(year, 1, 9999);
-        if (month === 2) {
-            return DateOnly.isLeapYear(year) ? 29 : 28;
+/**
+ * Tries to parse a date-only string.
+ * @param {string} s A string containing GUID to convert.
+ * @returns {DateOnly} A date if valid, otherwise unparsable.
+ */
+export function tryParse(s: string | null | undefined): DateOnly | Unparsable | undefined {
+    if (Svo.isEmpty(s)) {
+        return undefined;
+    }
+    try {
+        const str = s!.trim();
+        const match = str.match(/^(\d{1,4})-(1[0-2]|0?\d)-(3[01]|[0-2]?\d)$/);
+        if (match?.length === 4) {
+            return create(Number.parseInt(match[1]), Number.parseInt(match[2]), Number.parseInt(match[3]));
         }
-        else {
-            return [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][Guard.int(month, 1, 12)];
+
+        const date = new Date(Date.parse(str));
+        if (Number.isFinite(date.getTime())) {
+            return create(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
         }
     }
+    catch { /* fall trough */ }
+    return new Unparsable("Not a valid date", s);
+}
 
-    /**
-     * Creates a date-only based on a date-time.
-     * @param {Date} d The date-time to convert.
-     * @returns {DateOnly} represting the (UTC) date part of the date-time.
-     */
-    public static fromDate(d: Date) : DateOnly {
-        return new DateOnly(d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate());
+/**
+  * @param year The year to check.
+  * @returns true if the year is a leap year.
+  */
+export function isLeapYear(year: number): boolean {
+    return !(year & 3 || year & 15 && !(year % 25));
+}
+
+/**
+ * @param year The year to check.
+ * @param month The month to check.
+ * @returns the total days for the specified year/month.
+ */
+export function daysPerMonth(year: number, month: number): number {
+    if (month === 2) {
+        return isLeapYear(year) ? 29 : 28;
     }
-
-    /**
-     * Parses a date-only string.
-     * @param {string} s A string containing date to convert.
-     * @returns {DateOnly} A GUID if valid, otherwise throws.
-     */
-    public static parse(s: string | null | undefined): DateOnly | undefined {
-        const svo = DateOnly.tryParse(s);
-
-        if (svo instanceof (Unparsable)) {
-            throw svo;
-        }
-        return svo;
+    else {
+        return [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month];
     }
+}
 
-    /**
-     * Tries to parse a date-only string.
-     * @param {string} s A string containing GUID to convert.
-     * @returns {DateOnly} A date if valid, otherwise unparsable.
-     */
-    public static tryParse(s: string | null | undefined): DateOnly | Unparsable | undefined {
-        if (Svo.isEmpty(s)) {
-            return undefined;
-        }
-        try {
-            const str = s!.trim();
-            const match = str.match(/^(\d{1,4})-(1[0-2]|0?\d)-(3[01]|[0-2]?\d)$/);
-            if (match?.length === 4) {
-                return new DateOnly(Number.parseInt(match[1]),Number.parseInt(match[2]), Number.parseInt(match[3]));
-            }
+function getLeapYears(year: number) {
+    const y = year - 1;
+    return ~~(y / 4)
+        + ~~(y / 400)
+        - ~~(y / 100);
+}
 
-            const date = new Date(Date.parse(str));
-            if (Number.isFinite(date.getTime())) {
-                return new DateOnly(date.getUTCFullYear(), date.getUTCMonth() +1, date.getUTCDate());
-            }
-        }
-        catch { /* fall trough */}
-        return new Unparsable("Not a valid date", s);
-    }
-
-    /**
-    * @returns the total number of days from 0001-01-01.
-    */
-    get #totalDays(): number {
-        return this.dayOfYear
-            + (this.year - 1) * 365
-            + DateOnly.#getLeapYears(this.year);
-    }
-
-    /**
-     * @returns the total of leap years that occurred before the specified year.
-     */
-    static #getLeapYears(year: number) {
-        const y = year - 1;
-        return ~~(y / 4)
-            + ~~(y / 400)
-            - ~~(y / 100);
-    }
-
-    /**
-     * @remarks String.ProtoType.padStart() is not available.
-     */
-    static #pad(n: number, padding?: number): string {
+function pad(n: number, padding?: number): string {
         let s = n.toString();
         while (s.length < (padding ?? 2)) {
             s = '0' + s;
         }
         return s;
     }
-}


### PR DESCRIPTION
It has been advocated by others (offline) and by [Douglas Crockford](https://www.youtube.com/watch?v=XFTOG895C7c) to abandon the use of `class`  and `this`, and use `Object.freeze()` to create objects that satisfy `interface`'s (or `type`'s). This PR is an attempt to see what is the result of this approach.

First practical challange: `expect(svo).toStrictEqual(other)` fails as the structure is not equal for equal SVO's as the included functions are not the same.