### PR TITLE
Update DevBox Installer version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.15.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
+        uses: jetify-com/devbox-install-action@v0.15.0
         with:
           project-path: devbox.json
       - name: Build

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install devbox
-      uses: jetify-com/devbox-install-action@v0.11.0
+      uses: jetify-com/devbox-install-action@v0.15.0
       with:
         project-path: devbox.json
 

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Install devbox
       uses: jetify-com/devbox-install-action@v0.15.0


### PR DESCRIPTION
This pull request updates the version of the `jetify-com/devbox-install-action` GitHub Action used in the CI and tag workflows. The action is upgraded from version `v0.11.0` to `v0.15.0` to ensure compatibility with the latest features and bug fixes.

Dependency updates in GitHub Actions:

* Upgraded `jetify-com/devbox-install-action` from `v0.11.0` to `v0.15.0` in `.github/workflows/ci.yaml`.
* Upgraded `jetify-com/devbox-install-action` from `v0.11.0` to `v0.15.0` in `.github/workflows/tag.yaml`.