### PR TITLE
Implement Unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ if (svo instanceof (Unparsable)) {
 }
 ```
 
+### Unknown state
+The `unknown` (singleton) allows to have an explicit unknown state. This allows
+union types that combine an SVO type with `Unknown`:
+
+``` TypeScript
+inteface contract {
+    email: EmailAddress | undefined | Unknown,
+}
+```
+
+The `.tryParse()`, and `.fromJSON()` methods are designed in such a way that
+ they can be chained with other types that might be extended with SVO's:
+
+``` TypeScript
+const s = ...
+const email = Unknown.tryParse(s) ?? EmailAddress.parse(s);
+```
+
 ## Types
 
 ### Clock
@@ -173,24 +191,24 @@ q.iban().optional(); // optional IBAN
 
 ## Interfaces
 
-### IFormattable
+### Formattable
 As JavaScript does not support method overloading, this interface makes explicit
 by including `toString()` and `format(f?: TOption)` that the `format` method
 should be the overloaded version of `toString`.
 
 ``` TypeScript
-interface IFormattable<string> {
+interface Formattable<TOption> {
     toString(): string;
-    format(f?: string): string;
+    format(f?: TOption): string;
 }
 ```
 
-### IEquatable
+### Equatable
 As JavaScript does not have a way to support equals overloading as a lot of 
 other languages do, but it gives something.
 
 ``` TypeScript
-interface IEquatable {
+interface Equatable {
     equals(other: any): boolean;
 }
 ```
@@ -211,11 +229,11 @@ function eq(l, r) {
 } 
 ```
 
-### IJsonStringifyable
+### JsonStringifyable
 To support `JSON.stringify()` this interface was introduced.
 
 ``` TypeScript
-interface IJsonStringifyable {
+interface JsonStringifyable {
     toJSON(): any;
 }
 ```

--- a/packages/qowaiv/specs/Unknown.spec.ts
+++ b/packages/qowaiv/specs/Unknown.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, test } from 'vitest';
+import { Unknown } from '../src/Unknown';
+const unknown = Unknown.instance;
+
+describe('Unknown', () => {
+
+    it('equals same instance', () => {
+
+        expect(unknown.equals(unknown)).toBe(true);
+    });
+
+    test.each([
+        null,
+        { },
+        true,
+        false,
+        42,
+        3.14159265359,
+        undefined,
+        "not unknown",
+        ""])
+        ('Does not equal other %s', (s) => {
+            expect(unknown.equals(s)).toBe(false);
+    });
+
+    it('toString() returns "?"', () => {
+
+        expect(unknown.toString()).toBe('?');
+    });
+
+    it('toJSON() returns "?"', () => {
+
+        expect(unknown.toJSON()).toBe('?');
+    });
+
+    it('format() returns "?"', () => {
+
+        expect(unknown.format('')).toBe('?');
+    });
+
+    it('fromJSON returns unknown for "?"', () => {
+
+        expect(Unknown.fromJSON('?')).toBe(unknown);
+    });
+
+    it('tryParse returns unknown for "?"', () => {
+
+        expect(Unknown.tryParse('?')).toBe(unknown);
+    });
+
+    it('fromJSON returns undefined for all but for "?"', () => {
+
+        expect(Unknown.fromJSON(true)).toBeUndefined();
+    });
+
+    test.each([
+        null,
+        { },
+        true,
+        false,
+        42,
+        3.14159265359,
+        undefined,
+        "not unknown",
+        ""])
+        ('fromJSON returns undefined for %s', (s) =>{
+            expect(Unknown.fromJSON(s)).toBeUndefined();
+    });
+
+    test.each([
+        null,
+        undefined,
+        "not unknown",
+        ""])
+        ('tryParse returns undefined for %s', (s) =>{
+            expect(Unknown.tryParse(s)).toBeUndefined();
+    });
+});

--- a/packages/qowaiv/src/Unknown.ts
+++ b/packages/qowaiv/src/Unknown.ts
@@ -1,0 +1,65 @@
+/**
+ * Represents a Globally unique identifier (GUID).
+ */
+export class Unknown implements Equatable, Formattable<any>, JsonStringifyable {
+
+    public static readonly instance = new Unknown();
+
+    /**
+     * @constructor
+     * @remarks It is the default constructor, for creating an actual GUID
+     *          you will normally use Guid.newGuid() or Guid.parse(string).
+     */
+    private constructor() {
+    }
+
+    /** 
+     * Returns a string that represents the current GUID.
+     */
+    public toString(): string {
+        return '?';
+    }
+    /** 
+     * Returns a string that represents unknown.
+     * @param {string} f the format to apply.
+     */
+    public format(f?: any): string {
+        return '?';
+    }
+    /** 
+     * @returns a JSON representation of unknown.
+     */
+    public toJSON(): string {
+        return '?';
+    }
+
+    /**
+     * @param other the object to compare with.
+     * @returns true if other is a GUID representing the same value.
+     */
+    public equals(other: unknown): boolean {
+        return other instanceof (Unknown);
+    }
+
+    /**
+      * Creates unknown from a JSON token.
+      * @param {any} token A JSON token representing unknown.
+      * @returns {Unknown | undefined} A GUID if valid, undefined if empty.
+      */
+    public static fromJSON(token: any): Unknown | undefined {
+        return token === '?'
+            ? Unknown.instance
+            : undefined;
+    }
+
+    /**
+     * Tries to parse an unknown string.
+     * @param {string} s A string containing an unknown to convert.
+     * @returns {Guid} An unknown if valid, otherwise undefined.
+     */
+    public static tryParse(s: string | null | undefined): Unknown | undefined {
+        return s === '?'
+            ? Unknown.instance
+            : undefined;
+    }
+}

--- a/packages/qowaiv/src/Unknown.ts
+++ b/packages/qowaiv/src/Unknown.ts
@@ -44,7 +44,7 @@ export class Unknown implements Equatable, Formattable<any>, JsonStringifyable {
     /**
       * Creates unknown from a JSON token.
       * @param {any} token A JSON token representing unknown.
-      * @returns {Unknown | undefined} A GUID if valid, undefined if empty.
+      * @returns {Unknown | undefined} An unknown if valid, undefined if empty.
       */
     public static fromJSON(token: any): Unknown | undefined {
         return token === '?'

--- a/packages/qowaiv/src/index.ts
+++ b/packages/qowaiv/src/index.ts
@@ -1,3 +1,7 @@
+// Unknown
+import { Unknown } from "./Unknown";
+export const unknown = Unknown.instance;
+
 // Helpers
 export { Guard } from "./Guard";
 export { Svo } from "./Svo";


### PR DESCRIPTION
The `unknown` (singleton) allows to have an explicit unknown state. This allows union types that combine an SVO type with `Unknown`:

``` TypeScript
inteface contract {
    email: EmailAddress | undefined | Unknown,
}
```

The `.tryParse()`, and `.fromJSON()` methods are designed in such a way that  they can be chained with other types that might be extended with SVO's:

``` TypeScript
const s = ...
const email = Unknown.tryParse(s) ?? EmailAddress.parse(s);
```

Closes #78 